### PR TITLE
Declare queue lazily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,117 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+#Others
 /.benchmarks
-/.cache
-/.coverage
-/.pytest_cache
-/.tox
 /benchmark*.svg
-/build
-/dist
-/*.egg-info
-/htmlcov
-__pycache__
+/.idea
+dump.rdb

--- a/dramatiq/broker.py
+++ b/dramatiq/broker.py
@@ -73,6 +73,7 @@ class Broker:
         self.actors = {}
         self.queues = {}
         self.delay_queues = set()
+        self.prepared_queues = set()
 
         self.actor_options = set()
         self.middleware = []
@@ -171,9 +172,21 @@ class Broker:
           actor(Actor): The actor being declared.
         """
         self.emit_before("declare_actor", actor)
-        self.declare_queue(actor.queue_name)
+        self.prepare_queue(actor.queue_name)
         self.actors[actor.actor_name] = actor
         self.emit_after("declare_actor", actor)
+
+    def prepare_queue(self, queue_name):  # pragma: no cover
+        """Maintain a list of queue to be declared when needed
+
+        Parameters:
+          queue_name(str): The name of the queue being prepared.
+        """
+        self.prepared_queues.add(queue_name)
+
+    def declare_prepared_queues(self):
+        for queue_name in self.prepared_queues:
+            self.declare_queue(queue_name)
 
     def declare_queue(self, queue_name):  # pragma: no cover
         """Declare a queue on this broker.  This method must be

--- a/dramatiq/brokers/rabbitmq.py
+++ b/dramatiq/brokers/rabbitmq.py
@@ -148,6 +148,8 @@ class RabbitmqBroker(Broker):
 
             except Exception:  # pragma: no cover
                 self.logger.debug("Encountered an error while closing %r.", channel_or_conn, exc_info=True)
+        self.channels = set()
+        self.connections = set()
         self.logger.debug("Channels and connections closed.")
 
     def consume(self, queue_name, prefetch=1, timeout=5000):
@@ -161,6 +163,7 @@ class RabbitmqBroker(Broker):
         Returns:
           Consumer: A consumer that retrieves messages from RabbitMQ.
         """
+        self.emit_before('consume')
         return _RabbitmqConsumer(self.parameters, queue_name, prefetch, timeout)
 
     def declare_queue(self, queue_name):

--- a/dramatiq/brokers/stub.py
+++ b/dramatiq/brokers/stub.py
@@ -51,6 +51,7 @@ class StubBroker(Broker):
         Returns:
           Consumer: A consumer that retrieves messages from Redis.
         """
+        self.emit_before('consume')
         try:
             return _StubConsumer(self.queues[queue_name], self.dead_letters, timeout)
         except KeyError:
@@ -96,10 +97,11 @@ class StubBroker(Broker):
                 },
             )
 
+        self.emit_before("enqueue", message, delay)
+
         if queue_name not in self.queues:
             raise QueueNotFound(queue_name)
 
-        self.emit_before("enqueue", message, delay)
         self.queues[queue_name].put(message.encode())
         self.emit_after("enqueue", message, delay)
         return message

--- a/dramatiq/middleware/__init__.py
+++ b/dramatiq/middleware/__init__.py
@@ -19,6 +19,7 @@ import platform
 
 from .age_limit import AgeLimit
 from .callbacks import Callbacks
+from .declare_queues import DeclareQueuesMiddleware
 from .middleware import Middleware, MiddlewareError, SkipMessage
 from .pipelines import Pipelines
 from .retries import Retries
@@ -51,7 +52,7 @@ if CURRENT_OS != "Windows":
 #: The list of middleware that are enabled by default.
 default_middleware = [
     AgeLimit, TimeLimit, ShutdownNotifications,
-    Callbacks, Pipelines, Retries
+    Callbacks, Pipelines, Retries, DeclareQueuesMiddleware
 ]
 
 if CURRENT_OS != "Windows":

--- a/dramatiq/middleware/declare_queues.py
+++ b/dramatiq/middleware/declare_queues.py
@@ -1,0 +1,9 @@
+from .middleware import Middleware
+
+
+class DeclareQueuesMiddleware(Middleware):
+    def before_consume(self, broker):
+        broker.declare_prepared_queues()
+
+    def before_enqueue(self, broker, *_):
+        broker.declare_prepared_queues()

--- a/dramatiq/middleware/middleware.py
+++ b/dramatiq/middleware/middleware.py
@@ -140,3 +140,9 @@ class Middleware:
 
         There is no ``after_worker_thread_boot``.
         """
+
+    def before_consume(self, broker):
+        """Called before consuming
+
+        There is no ``after_consume``.
+        """


### PR DESCRIPTION
Currently, a queue is declared when an actor is. This means a connection
to broker must be established when actors are imported. It leads to some
difficulties when you need to change some configuration parameters after
actors have been imported.

This change declare queue lazily, meaning on first message enqueuing.