### PR TITLE
add local broker (equivalent of CELERY_ALWAYS_EAGER)

### DIFF
--- a/dramatiq/brokers/local.py
+++ b/dramatiq/brokers/local.py
@@ -1,0 +1,64 @@
+# This file is a part of Dramatiq.
+#
+# Copyright (C) 2017,2018 CLEARTYPE SRL <bogdan@cleartype.io>
+#
+# Dramatiq is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# Dramatiq is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from ..broker import Broker
+from ..results import Results
+from ..results.backends import LocalBackend
+
+
+class LocalBroker(Broker):
+    """ Broker that calculate the message result immediately
+
+    It can only be used with LocalBackend as a result backend
+    """
+    def __init__(self, middleware=None):
+        super().__init__(middleware)
+
+        # It use LocalBackend
+        self.add_middleware(Results(backend=LocalBackend()))
+
+    def add_middleware(self, middleware, *, before=None, after=None):
+        if isinstance(middleware, Results) and not isinstance(middleware.backend, LocalBackend):
+            raise RuntimeError("LocalBroker can only be used with LocalBackend.")
+        super().add_middleware(middleware, before=before, after=after)
+
+    def consume(self, queue_name, prefetch=1, timeout=100):
+        raise ValueError('LocalBroker is not destined to use with a Worker')
+
+    def declare_queue(self, queue_name):
+        pass
+
+    def enqueue(self, message, *, delay=None):
+        """Enqueue and compute a message.
+
+        Parameters:
+          message(Message): The message to enqueue
+          delay(int): ignored
+        """
+        actor = self.get_actor(message.actor_name)
+        self.emit_before("process_message", message)
+        res = actor(*message.args, **message.kwargs)
+        self.emit_after("process_message", message, result=res)
+        return message
+
+    def flush(self, _):
+        pass
+
+    def flush_all(self):
+        pass
+
+    def join(self, *_):
+        return

--- a/dramatiq/middleware/__init__.py
+++ b/dramatiq/middleware/__init__.py
@@ -42,7 +42,8 @@ __all__ = [
 
     # Middlewares
     "AgeLimit", "Callbacks", "Pipelines", "Retries",
-    "Shutdown", "ShutdownNotifications", "TimeLimit", "TimeLimitExceeded",
+    "Shutdown", "ShutdownNotifications", "TimeLimit",
+    "TimeLimitExceeded", "DeclareQueuesMiddleware"
 ]
 
 if CURRENT_OS != "Windows":

--- a/dramatiq/results/backends/__init__.py
+++ b/dramatiq/results/backends/__init__.py
@@ -17,6 +17,7 @@
 
 import warnings
 
+from .local import LocalBackend
 from .stub import StubBackend
 
 try:
@@ -35,4 +36,4 @@ except ImportError:  # pragma: no cover
         "to add support for that backend.", ImportWarning,
     )
 
-__all__ = ["StubBackend", "MemcachedBackend", "RedisBackend"]
+__all__ = ["StubBackend", "MemcachedBackend", "RedisBackend", "LocalBackend"]

--- a/dramatiq/results/backends/local.py
+++ b/dramatiq/results/backends/local.py
@@ -1,0 +1,22 @@
+from ..backend import ResultBackend
+from ..errors import ResultError
+
+
+class LocalBackend(ResultBackend):
+    """An in-memory result backend. For use with LocalBroker only.
+
+    We need to be careful here: if an actor store its results and never retrieves it, we may store all its results
+    and never delete it. Resulting in a memory leak.
+    """
+
+    results = {}
+
+    def _get(self, message_key):
+        try:
+            return self.results.pop(message_key)
+        except KeyError:
+            message = 'The result corresponding to the message %s was not saved (have you set store_result = True)'
+            raise ResultError(message % message_key)
+
+    def _store(self, message_key, result, _):
+        self.results[message_key] = result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import redis
 
 import dramatiq
 from dramatiq import Worker
+from dramatiq.brokers.local import LocalBroker
 from dramatiq.brokers.rabbitmq import RabbitmqBroker
 from dramatiq.brokers.stub import StubBroker
 from dramatiq.rate_limits import backends as rl_backends
@@ -60,6 +61,16 @@ def stub_broker():
 def rabbitmq_broker():
     broker = RabbitmqBroker(host="127.0.0.1")
     check_rabbitmq(broker)
+    broker.emit_after("process_boot")
+    dramatiq.set_broker(broker)
+    yield broker
+    broker.flush_all()
+    broker.close()
+
+
+@pytest.fixture()
+def local_broker():
+    broker = LocalBroker()
     broker.emit_after("process_boot")
     dramatiq.set_broker(broker)
     yield broker

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1,0 +1,59 @@
+import pytest
+
+import dramatiq
+from dramatiq import group
+from dramatiq.results import Results
+from dramatiq.results.backends import LocalBackend
+
+
+@pytest.mark.parametrize("backend", ["memcached", "redis", "stub"])
+def test_local_broker_cannot_have_non_local_backend(local_broker, backend, result_backends):
+    # Given a backend
+    result_backend = result_backends[backend]
+
+    # Which is not a LocalBackend
+    assert not isinstance(backend, LocalBackend)
+
+    # Cannot be used with LocalBroker
+    with pytest.raises(RuntimeError):
+        local_broker.add_middleware(Results(backend=result_backend))
+
+
+def test_local_broker_get_result_in_message(local_broker):
+    # Given that I have an actor that stores its results
+    @dramatiq.actor(store_results=True)
+    def do_work():
+        return 1
+
+    # When I send that actor a message
+    message = do_work.send()
+
+    # I should get the right result
+    assert message.get_result() == 1
+
+
+def test_local_broker_with_pipes(local_broker):
+    # Given that I have an actor that stores its results
+    @dramatiq.actor(store_results=True)
+    def add(a, b):
+        return a + b
+
+    # When I run a pipe
+    pipe = add.message(1, 2) | add.message(3)
+    pipe.run()
+
+    # I should get the right result
+    assert pipe.get_result() == 6
+
+
+def test_local_broker_with_groups(local_broker):
+    # Given that I have an actor that stores its results
+    @dramatiq.actor(store_results=True)
+    def add(a, b):
+        return a + b
+
+    # When I run a group
+    g = group([add.message(1, 2), add.message(3, 4), add.message(4, 5)])
+    g.run()
+
+    assert list(g.get_results()) == [3, 7, 9]


### PR DESCRIPTION
The local broker just run the actor instead of enqueuing the message.
I used a LocalBackend to store the result to stay closer to how the library works.