### PR TITLE
Fix RedisBackend.get_result saving a FogottenResullt every time

### DIFF
--- a/remoulade/results/backends/redis.py
+++ b/remoulade/results/backends/redis.py
@@ -87,9 +87,9 @@ class RedisBackend(ResultBackend):
         else:
             if forget:
                 with self.client.pipeline() as pipe:
-                    pipe.rpop(message_key)
-                    pipe.lpush(message_key, self.encoder.encode(ForgottenResult.asdict()))
-                    data = pipe.execute()[0]
+                    pipe.rpushx(message_key, self.encoder.encode(ForgottenResult.asdict()))
+                    pipe.lpop(message_key)
+                    data = pipe.execute()[1]
             else:
                 data = self.client.rpoplpush(message_key, message_key)
 


### PR DESCRIPTION
This should happen only if the key is already present