### PR TITLE
fix: rabbitMQ declare queue on each ConnectionError

### DIFF
--- a/remoulade/brokers/rabbitmq.py
+++ b/remoulade/brokers/rabbitmq.py
@@ -81,7 +81,6 @@ class RabbitmqBroker(Broker):
         self.connections = set()
         self.channels = set()
         self.queues = set()
-        self.declared_queues = set()
         self.state = local()
 
     @property
@@ -181,11 +180,9 @@ class RabbitmqBroker(Broker):
           AMQPConnectionError or AMQPChannelError: If the underlying channel or connection has been closed.
         """
         for queue_name in self.queues:
-            if queue_name not in self.declared_queues:
-                self._declare_queue(queue_name)
-                self._declare_dq_queue(queue_name)
-                self._declare_xq_queue(queue_name)
-                self.declared_queues.add(queue_name)
+            self._declare_queue(queue_name)
+            self._declare_dq_queue(queue_name)
+            self._declare_xq_queue(queue_name)
 
     def declare_queue(self, queue_name):
         """Declare a queue.  Has no effect if a queue with the given

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -48,7 +48,6 @@ def test_rabbitmq_queues_created_lazily(rabbitmq_broker):
 
     # queue_name should be in prepared_queues
     assert add.queue_name in rabbitmq_broker.queues
-    assert add.queue_name not in rabbitmq_broker.declared_queues
 
     # nothing is sent so RabbitMQ before sending a message
     assert len(rabbitmq_broker.connections) == 0


### PR DESCRIPTION
Even if queue is already marked as declared locally.
If there is an issue with rmq and the queue are deleted,
it should be recreated without a worker restart.