### PR TITLE
feature(cancel): add middleware to cancel a  message

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file.
 `Unreleased`_
 -------------
 
+`0.9.0`_ -- 2018-01-18
+----------------------
+
+Added
+^^^^^
+
+* |Cancel| middleware, and a |message_cancel| method to prevent processing of messages which have been enqueued
+* |cancel_on_error| which cancel all group members on member failure.
 
 `0.8.2`_ -- 2018-12-31
 ----------------------
@@ -156,6 +164,7 @@ Fixed
 * pipe_ignore was not recovered from right message
 
 .. _Unreleased: https://github.com/wiremind/remoulade/compare/v0.8.2...HEAD
+.. _0.9.0: https://github.com/wiremind/remoulade/releases/tag/v0.9.0
 .. _0.8.2: https://github.com/wiremind/remoulade/releases/tag/v0.8.2
 .. _0.8.1: https://github.com/wiremind/remoulade/releases/tag/v0.8.1
 .. _0.8.0: https://github.com/wiremind/remoulade/releases/tag/v0.8.0

--- a/docs/source/global.rst
+++ b/docs/source/global.rst
@@ -62,6 +62,9 @@
 .. |pipeline_results_get| replace:: :meth:`get<remoulade.CollectionResults.get>`
 .. |completed_count| replace:: :meth:`completed_count<remoulade.CollectionResults.completed_count>`
 .. |completed| replace:: :meth:`completed<remoulade.Result.completed>`
+.. |Cancel| replace:: :class:`Cancel<remoulade.cancel.Cancel>`
+.. |message_cancel| replace:: :meth:`cancel<remoulade.message.cancel>`
+.. |cancel_on_error| replace:: :param:`cancel_on_error<remoulade.group.cancel_on_error>`
 
 
 

--- a/remoulade/cancel/__init__.py
+++ b/remoulade/cancel/__init__.py
@@ -1,0 +1,22 @@
+# This file is a part of Remoulade.
+#
+# Copyright (C) 2017,2018 WIREMIND SAS <dev@wiremind.fr>
+#
+# Remoulade is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# Remoulade is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from .backend import CancelBackend
+from .errors import MessageCanceled
+from .middleware import Cancel
+
+__all__ = ["Cancel", "CancelBackend", "MessageCanceled"]

--- a/remoulade/cancel/backend.py
+++ b/remoulade/cancel/backend.py
@@ -1,0 +1,42 @@
+# This file is a part of Remoulade.
+#
+# Copyright (C) 2017,2018 WIREMIND SAS <dev@wiremind.fr>
+#
+# Remoulade is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# Remoulade is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from typing import Iterable
+
+DEFAULT_CANCELLATION_TTL = 3600
+
+
+class CancelBackend:
+    """ABC for cancel backends.
+
+        Parameters:
+          cancellation_ttl(int): The minimal amount of seconds message cancellations
+            should be kept in the backend (default 1h).
+        """
+    def __init__(self, *, cancellation_ttl=None):
+        self.cancellation_ttl = cancellation_ttl or DEFAULT_CANCELLATION_TTL
+
+    def is_canceled(self, message_id: str) -> bool:
+        """ Return true if the message has been canceled """
+        raise NotImplementedError("%(classname)r does not implement is_canceled" % {
+            "classname": type(self).__name__,
+        })
+
+    def cancel(self, message_ids: Iterable[str]) -> None:
+        """ Mark a message as canceled """
+        raise NotImplementedError("%(classname)r does not implement cancel" % {
+            "classname": type(self).__name__,
+        })

--- a/remoulade/cancel/backends/__init__.py
+++ b/remoulade/cancel/backends/__init__.py
@@ -1,0 +1,29 @@
+# This file is a part of Remoulade.
+#
+# Copyright (C) 2017,2018 WIREMIND SAS <dev@wiremind.fr>
+#
+# Remoulade is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# Remoulade is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import warnings
+
+from .stub import StubBackend
+
+try:
+    from .redis import RedisBackend
+except ImportError:  # pragma: no cover
+    warnings.warn(
+        "RedisBackend is not available.  Run `pip install remoulade[redis]` "
+        "to add support for that backend.", ImportWarning,
+    )
+
+__all__ = ["RedisBackend", "StubBackend"]

--- a/remoulade/cancel/backends/redis.py
+++ b/remoulade/cancel/backends/redis.py
@@ -1,0 +1,64 @@
+# This file is a part of Remoulade.
+#
+# Copyright (C) 2017,2018 WIREMIND SAS <dev@wiremind.fr>
+#
+# Remoulade is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# Remoulade is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import time
+from typing import Iterable
+
+import redis
+
+from ..backend import CancelBackend
+
+
+class RedisBackend(CancelBackend):
+    """A cancel backend for Redis_.
+
+    It uses a sorted set with the message_id as member and the timestamp of the addition as a score.
+    We can check if message has been canceled if it belongs to the set.
+    And on each message cancel we delete all the cancellations that are older than cancellation_ttl (ZREMRANGEBYSCORE).
+    This prevents unlimited set growth.
+
+    Parameters:
+      cancellation_ttl(int): The minimal amount of seconds message cancellations
+        should be kept in the backend.
+      key(str): A string to serve as key for the sorted set.
+      client(Redis): An optional client.  If this is passed,
+        then all other parameters are ignored.
+      url(str): An optional connection URL.  If both a URL and
+        connection parameters are provided, the URL is used.
+      **parameters(dict): Connection parameters are passed directly
+        to :class:`redis.Redis`.
+
+    .. _redis: https://redis.io
+    """
+
+    def __init__(self, *, cancellation_ttl=None, key="remoulade-cancellations", client=None, url=None, **parameters):
+        super().__init__(cancellation_ttl=cancellation_ttl)
+
+        if url:
+            parameters["connection_pool"] = redis.ConnectionPool.from_url(url)
+
+        self.key = key
+        self.client = client or redis.Redis(**parameters)
+
+    def is_canceled(self, message_id: str) -> bool:
+        return self.client.zscore(self.key, message_id) is not None
+
+    def cancel(self, message_ids: Iterable[str]) -> None:
+        timestamp = time.time()
+        with self.client.pipeline() as pipe:
+            pipe.zadd(self.key, {message_id: timestamp for message_id in message_ids})
+            pipe.zremrangebyscore(self.key, '-inf', timestamp - self.cancellation_ttl)
+            pipe.execute()

--- a/remoulade/cancel/backends/stub.py
+++ b/remoulade/cancel/backends/stub.py
@@ -1,0 +1,41 @@
+# This file is a part of Remoulade.
+#
+# Copyright (C) 2017,2018 WIREMIND SAS <dev@wiremind.fr>
+#
+# Remoulade is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# Remoulade is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import time
+from typing import Iterable
+
+from ..backend import CancelBackend
+
+
+class StubBackend(CancelBackend):
+    """An in-memory cancel backend.  For use in unit tests.
+
+    Parameters:
+      cancellation_ttl(int): The minimal amount of seconds message cancellations
+        should be kept in the backend.
+    """
+
+    def __init__(self, *, cancellation_ttl=None):
+        super().__init__(cancellation_ttl=cancellation_ttl)
+        self.cancellations = {}
+
+    def is_canceled(self, message_id: str) -> bool:
+        return self.cancellations.get(message_id, -float('inf')) > time.time() - self.cancellation_ttl
+
+    def cancel(self, message_ids: Iterable[str]) -> None:
+        timestamp = time.time()
+        for message_id in message_ids:
+            self.cancellations[message_id] = timestamp

--- a/remoulade/cancel/errors.py
+++ b/remoulade/cancel/errors.py
@@ -1,0 +1,21 @@
+# This file is a part of Remoulade.
+#
+# Copyright (C) 2017,2018 WIREMIND SAS <dev@wiremind.fr>
+#
+# Remoulade is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# Remoulade is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from ..middleware.middleware import MiddlewareError
+
+
+class MessageCanceled(MiddlewareError):
+    """ Raised when a message has been canceled before it was processed """

--- a/remoulade/cancel/middleware.py
+++ b/remoulade/cancel/middleware.py
@@ -1,0 +1,99 @@
+# This file is a part of Remoulade.
+#
+# Copyright (C) 2017,2018 WIREMIND SAS <dev@wiremind.fr>
+#
+# Remoulade is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# Remoulade is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is a part of Remoulade.
+#
+# Copyright (C) 2017,2018 CLEARTYPE SRL <bogdan@cleartype.io>
+#
+# Remoulade is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# Remoulade is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from ..logging import get_logger
+from ..middleware import Middleware
+from .errors import MessageCanceled
+
+
+class Cancel(Middleware):
+    """Middleware that check if a message has been canceled before processing it
+    If the message has been canceled raise a MessageCanceled to prevent message processing.
+
+    Example:
+
+      >>> from remoulade.cancel import Cancel
+      >>> from remoulade.cancel.backends import RedisBackend
+      >>> backend = RedisBackend()
+      >>> broker.add_middleware(Cancel(backend=backend))
+
+      >>> @remoulade.actor(store_results=True)
+      ... def add(x, y):
+      ...   return x + y
+
+      >>> broker.declare_actor(add)
+      >>> message = add.send(1, 2)
+      >>> message.cancel()
+      3
+
+    Parameters:
+      backend(CancelBackend): The cancel backend to use to check
+        cancellations.
+      cancelable(bool): Whether or not  an actor can be canceled.
+        Defaults to False and can be set on a per-actor basis.
+    """
+
+    def __init__(self, *, backend=None, cancelable=False):
+        self.logger = get_logger(__name__, type(self))
+        self.backend = backend
+        self.cancelable = cancelable
+
+    @property
+    def actor_options(self):
+        return {
+            "cancelable"
+        }
+
+    def before_process_message(self, broker, message):
+        actor = broker.get_actor(message.actor_name)
+
+        cancelable = actor.options.get("cancelable", self.cancelable)
+        if not cancelable:
+            return
+
+        if self.backend.is_canceled(message.message_id):
+            raise MessageCanceled("Message %s has been canceled" % message.message_id)
+
+    def after_process_message(self, broker, message, *, result=None, exception=None):
+        """ Cancel all the messages in the group if one of the message of the group fail"""
+        from ..composition import GroupInfo
+
+        if exception is None:
+            return
+
+        group_info = message.options.get("group_info")
+        if not group_info:
+            return
+
+        group_info = GroupInfo(**group_info)
+        if group_info.cancel_on_error:
+            self.backend.cancel(group_info.message_ids)

--- a/remoulade/composition_result.py
+++ b/remoulade/composition_result.py
@@ -34,20 +34,20 @@ class CollectionResults:
     def __len__(self):
         return len(self._message_ids)
 
-    def asdict(self):
-        result = []
-        for child in self.children:
-            result.append(child.asdict())
-        return result
-
     @classmethod
-    def from_dict(cls, group_results):
+    def from_message_ids(cls, message_ids):
         children = []
-        for result in group_results:
-            if isinstance(result, list):
-                child = cls.from_dict(result)
+        for message_id in message_ids:
+            # it's a pipeline
+            if isinstance(message_id, list):
+                last = message_id[-1]
+                # it's a group
+                if isinstance(last, list):
+                    child = cls.from_message_ids(last)
+                else:
+                    child = Result(message_id=last)
             else:
-                child = Result(**result)
+                child = Result(message_id=message_id)
             children.append(child)
         return CollectionResults(children)
 

--- a/remoulade/errors.py
+++ b/remoulade/errors.py
@@ -69,7 +69,12 @@ class RateLimitExceeded(RemouladeError):
 
 
 class NoResultBackend(BrokerError):
-    """Raised when trying to access a the result backend on a broker without it
+    """Raised when trying to access the result backend on a broker without it
+    """
+
+
+class NoCancelBackend(BrokerError):
+    """Raised when trying to access the cancel backend on a broker without it
     """
 
 

--- a/remoulade/message.py
+++ b/remoulade/message.py
@@ -107,6 +107,12 @@ class Message(namedtuple("Message", (
         """ Build message for pipeline """
         return self.copy(options=options)
 
+    def cancel(self):
+        """ Mark a message as canceled """
+        broker = get_broker()
+        backend = broker.get_cancel_backend()
+        backend.cancel([self.message_id])
+
     @property
     def result(self):
         broker = get_broker()

--- a/remoulade/middleware/middleware.py
+++ b/remoulade/middleware/middleware.py
@@ -109,6 +109,10 @@ class Middleware:
         """Called instead of ``after_process_message`` after a message
         has been skippped.
         """
+    def after_message_canceled(self, broker, message):
+        """Called instead of ``after_process_message`` after a message
+        has been canceled.
+        """
 
     def after_process_boot(self, broker):
         """Called immediately after subprocess start up.

--- a/remoulade/middleware/pipelines.py
+++ b/remoulade/middleware/pipelines.py
@@ -49,7 +49,7 @@ class Pipelines(Middleware):
         pipe_target = message.options.get("pipe_target")
         group_info = message.options.get("group_info")
         if group_info:
-            group_info = GroupInfo.from_dict(**group_info)
+            group_info = GroupInfo(**group_info)
 
         if pipe_target is not None:
 
@@ -90,7 +90,7 @@ class Pipelines(Middleware):
 
         if not pipe_ignore:
             if group_info:
-                result = self._get_group_result(group_info)
+                result = list(group_info.results.get(forget=True))
             next_message = next_message.copy(args=next_message.args + (result,))
 
         broker.enqueue(next_message)
@@ -113,11 +113,4 @@ class Pipelines(Middleware):
 
         group_completion = result_backend.increment_group_completion(group_info.group_id)
 
-        return group_completion >= group_info.count
-
-    @staticmethod
-    def _get_group_result(group_info):
-        if group_info.results is None:
-            raise ResultNotStored('An actor in the group do not have store_result=True')
-
-        return list(group_info.results.get(forget=True))
+        return group_completion >= group_info.children_count

--- a/remoulade/middleware/prometheus.py
+++ b/remoulade/middleware/prometheus.py
@@ -166,6 +166,7 @@ class Prometheus(Middleware):
             self.total_errored_messages.labels(*labels).inc()
 
     after_skip_message = after_process_message
+    after_message_canceled = after_process_message
 
 
 class _ExpositionServer(Thread):

--- a/remoulade/middleware/shutdown.py
+++ b/remoulade/middleware/shutdown.py
@@ -86,3 +86,4 @@ class ShutdownNotifications(Middleware):
             self.notifications.remove(thread_id)
 
     after_skip_message = after_process_message
+    after_message_canceled = after_process_message

--- a/remoulade/middleware/time_limit.py
+++ b/remoulade/middleware/time_limit.py
@@ -90,3 +90,4 @@ class TimeLimit(Middleware):
         self.deadlines[threading.get_ident()] = None
 
     after_skip_message = after_process_message
+    after_message_canceled = after_process_message

--- a/remoulade/worker.py
+++ b/remoulade/worker.py
@@ -22,6 +22,7 @@ from itertools import chain
 from queue import Empty, PriorityQueue
 from threading import Event, Thread
 
+from .cancel import MessageCanceled
 from .common import current_millis, iter_queue, join_all, q_name
 from .errors import ActorNotFound, ConnectionError, RateLimitExceeded
 from .logging import get_logger
@@ -401,6 +402,10 @@ class _WorkerThread(Thread):
         except SkipMessage:
             self.logger.warning("Message %s was skipped.", message)
             self.broker.emit_after("skip_message", message)
+
+        except MessageCanceled:
+            self.logger.warning("Message %s has been canceled", message)
+            self.broker.emit_after("message_canceled", message)
 
         except BaseException as e:
             if isinstance(e, RateLimitExceeded):

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -1,0 +1,94 @@
+import time
+
+import pytest
+
+import remoulade
+from remoulade import group
+from remoulade.cancel import Cancel
+from remoulade.errors import NoCancelBackend
+
+
+@pytest.mark.parametrize("cancel", [True, False])
+def test_actors_can_be_canceled(stub_broker, stub_worker, cancel_backend, cancel):
+    # Given a cancel backend
+    # And a broker with the cancel middleware
+    stub_broker.add_middleware(Cancel(backend=cancel_backend))
+
+    has_been_called = []
+
+    # And an actor that is cancelable
+    @remoulade.actor(cancelable=True)
+    def do_work():
+        has_been_called.append(1)
+
+    # And this actor is declared
+    stub_broker.declare_actor(do_work)
+
+    # When I send that actor a message
+    message = do_work.send()
+
+    # If I cancel the message
+    if cancel:
+        message.cancel()
+
+    stub_broker.join(do_work.queue_name)
+    stub_worker.join()
+
+    # It should not be called
+    assert bool(has_been_called) != cancel
+
+
+def test_cancellations_not_stored_forever(cancel_backend):
+    # Given a cancel backend which store the cancellations 1 second
+    cancel_backend.cancellation_ttl = 1
+
+    # If we cancel some messages
+    cancel_backend.cancel('a')
+    # Then wait some time
+    time.sleep(1)
+    # And call again cancel
+    cancel_backend.cancel('c')
+
+    # the first cancellation should have been forgotten
+    assert not cancel_backend.is_canceled('a')
+
+
+def test_group_are_canceled_on_actor_failure(stub_broker, stub_worker, cancel_backend):
+    # Given a cancel backend
+    # And a broker with the cancel middleware
+    stub_broker.add_middleware(Cancel(backend=cancel_backend))
+
+    has_been_called = []
+
+    # And an actor that is cancelable
+    @remoulade.actor(cancelable=True)
+    def do_work():
+        has_been_called.append(1)
+        raise ValueError()
+
+    # And this actor is declared
+    stub_broker.declare_actor(do_work)
+
+    g = group((do_work.message() for _ in range(4)), cancel_on_error=True)
+
+    # When I group a few jobs together and run it
+    g.run()
+
+    stub_broker.join(do_work.queue_name)
+    stub_worker.join()
+
+    # All actors should have been canceled
+    assert all(cancel_backend.is_canceled(child.message_id) for child in g.children)
+
+
+def test_cannot_cancel_on_error_if_no_cancel(stub_broker):
+    # Given an actor
+    @remoulade.actor()
+    def do_work():
+        return 42
+
+    # And this actor is declared
+    stub_broker.declare_actor(do_work)
+
+    with pytest.raises(NoCancelBackend):
+        group((do_work.message() for _ in range(4)), cancel_on_error=True)


### PR DESCRIPTION
Add a method cancel to Message to prevent message processing even if
if already has been enqueued.
Add a cancel_on_error option to groups which cancel all group members on
actor failure.
fix #51