### PR TITLE
fix(group-pipeline): forget happen after pipe_taget has been enqueued

### DIFF
--- a/remoulade/composition_result.py
+++ b/remoulade/composition_result.py
@@ -32,7 +32,7 @@ class CollectionResults:
         self.children = list(children)
 
     def __len__(self):
-        return len(self._message_ids)
+        return len(self.message_ids)
 
     @classmethod
     def from_message_ids(cls, message_ids):
@@ -65,11 +65,11 @@ class CollectionResults:
         return self.completed_count == len(self)
 
     @property
-    def _message_ids(self):
+    def message_ids(self):
         message_ids = []
         for child in self.children:
             if isinstance(child, CollectionResults):
-                message_ids += child._message_ids
+                message_ids += child.message_ids
             else:
                 message_ids += [child.message_id]
         return message_ids
@@ -91,7 +91,7 @@ class CollectionResults:
         broker = get_broker()
         backend = broker.get_result_backend()
         # we could use message.completed here but we just want to make 1 call to get_status
-        return backend.get_status(self._message_ids)
+        return backend.get_status(self.message_ids)
 
     def get(self, *, block=False, timeout=None, raise_on_error=True, forget=False):
         """Get the results of each job in the collection.

--- a/remoulade/middleware/middleware.py
+++ b/remoulade/middleware/middleware.py
@@ -153,3 +153,6 @@ class Middleware:
 
         There is no ``after_worker_thread_boot``.
         """
+
+    def after_enqueue_pipe_target(self, broker, group_info):
+        """ Called after the pipe target of a message has been enqueued """

--- a/remoulade/middleware/pipelines.py
+++ b/remoulade/middleware/pipelines.py
@@ -58,6 +58,9 @@ class Pipelines(Middleware):
                     return
 
                 self._send_next_message(pipe_target, broker, result, group_info)
+
+                broker.emit_after('enqueue_pipe_target', group_info)
+
             except (NoResultBackend, ResultNotStored) as e:
                 self.logger.error(str(e))
                 message.fail()
@@ -90,7 +93,7 @@ class Pipelines(Middleware):
 
         if not pipe_ignore:
             if group_info:
-                result = list(group_info.results.get(forget=True))
+                result = list(group_info.results.get())
             next_message = next_message.copy(args=next_message.args + (result,))
 
         broker.enqueue(next_message)

--- a/remoulade/results/backends/local.py
+++ b/remoulade/results/backends/local.py
@@ -25,8 +25,9 @@ class LocalBackend(ResultBackend):
         except KeyError:
             return Missing
 
-    def _store(self, message_key, result, _):
-        self.results[message_key] = result
+    def _store(self, message_keys, results, _):
+        for (message_key, result) in zip(message_keys, results):
+            self.results[message_key] = result
 
     def increment_group_completion(self, group_id: str) -> int:
         group_completion_key = self.build_group_completion_key(group_id)

--- a/remoulade/results/backends/redis.py
+++ b/remoulade/results/backends/redis.py
@@ -106,11 +106,12 @@ class RedisBackend(ResultBackend):
         result = BackendResult(**self.encoder.decode(data))
         return self.process_result(result, raise_on_error)
 
-    def _store(self, message_key, result, ttl):
+    def _store(self, message_keys, results, ttl):
         with self.client.pipeline() as pipe:
-            pipe.delete(message_key)
-            pipe.lpush(message_key, self.encoder.encode(result))
-            pipe.pexpire(message_key, ttl)
+            for (message_key, result) in zip(message_keys, results):
+                pipe.delete(message_key)
+                pipe.lpush(message_key, self.encoder.encode(result))
+                pipe.pexpire(message_key, ttl)
             pipe.execute()
 
     def increment_group_completion(self, group_id: str) -> int:

--- a/remoulade/results/backends/stub.py
+++ b/remoulade/results/backends/stub.py
@@ -43,10 +43,11 @@ class StubBackend(ResultBackend):
             return self.encoder.decode(data)
         return Missing
 
-    def _store(self, message_key, result, ttl):
-        result_data = self.encoder.encode(result)
-        expiration = time.monotonic() + int(ttl / 1000)
-        self.results[message_key] = (result_data, expiration)
+    def _store(self, message_keys, results, ttl):
+        for (message_key, result) in zip(message_keys, results):
+            result_data = self.encoder.encode(result)
+            expiration = time.monotonic() + int(ttl / 1000)
+            self.results[message_key] = (result_data, expiration)
 
     def increment_group_completion(self, group_id: str) -> int:
         group_completion_key = self.build_group_completion_key(group_id)

--- a/remoulade/results/middleware.py
+++ b/remoulade/results/middleware.py
@@ -110,3 +110,8 @@ class Results(Middleware):
             message_ids |= self._get_children_message_ids(broker, message.options.get("pipe_target"))
 
         return message_ids
+
+    def after_enqueue_pipe_target(self, broker, group_info):
+        """ After a pipe target has been enqueued, we need to forget the result of the group (if it's a group) """
+        if group_info:
+            self.backend.forget_results([group_info.message_ids], self.result_ttl)


### PR DESCRIPTION
this fix an issue when the pipe_target could not be enqueued, the
message is retried and the results of the group has been forgotten.