### PR TITLE
fix: remove ResultNotStored error

### DIFF
--- a/remoulade/errors.py
+++ b/remoulade/errors.py
@@ -76,8 +76,3 @@ class NoResultBackend(BrokerError):
 class NoCancelBackend(BrokerError):
     """Raised when trying to access the cancel backend on a broker without it
     """
-
-
-class ResultNotStored(RemouladeError):
-    """ Raised when trying to access Message|Pipeline|Group result with one or more actor not have store_results=True
-    """

--- a/remoulade/message.py
+++ b/remoulade/message.py
@@ -22,7 +22,6 @@ from .broker import get_broker
 from .common import generate_unique_id
 from .composition import pipeline
 from .encoder import Encoder, JSONEncoder
-from .errors import ResultNotStored
 from .result import Result
 
 #: The global encoder instance.
@@ -115,10 +114,6 @@ class Message(namedtuple("Message", (
 
     @property
     def result(self):
-        broker = get_broker()
-        actor = broker.get_actor(actor_name=self.actor_name)
-        if not actor.options.get('store_results'):
-            raise ResultNotStored('There cannot be any result to an actor without store_results=True')
         return Result(message_id=self.message_id)
 
     def __str__(self):

--- a/remoulade/middleware/pipelines.py
+++ b/remoulade/middleware/pipelines.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from ..errors import NoResultBackend, ResultNotStored
+from ..errors import NoResultBackend
 from ..logging import get_logger
 from .middleware import Middleware
 
@@ -61,7 +61,7 @@ class Pipelines(Middleware):
 
                 broker.emit_after('enqueue_pipe_target', group_info)
 
-            except (NoResultBackend, ResultNotStored) as e:
+            except NoResultBackend as e:
                 self.logger.error(str(e))
                 message.fail()
 

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -5,7 +5,6 @@ import pytest
 
 import remoulade
 from remoulade import CollectionResults, group, pipeline
-from remoulade.errors import ResultNotStored
 from remoulade.results import ErrorStored, ResultMissing, Results, ResultTimeout
 
 
@@ -105,31 +104,6 @@ def test_pipe_ignore_actor_options(stub_broker, stub_worker, result_backend):
     pipe.run()
 
     assert pipe.result.get(block=True) == 1
-
-
-def test_pipeline_cannot_have_actor_without_store_results(stub_broker, stub_worker, result_backend):
-    # And a broker with the results middleware
-    stub_broker.add_middleware(Results(backend=result_backend))
-
-    # And an actor that return something
-    @remoulade.actor()
-    def do_nothing():
-        return 0
-
-    # Nothing should be sent to pipe ignored
-    @remoulade.actor(store_results=True, pipe_ignore=True)
-    def pipe_ignored(*args):
-        assert len(args) == 0
-        return 1
-
-    # And these actors are declared
-    stub_broker.declare_actor(do_nothing)
-    stub_broker.declare_actor(pipe_ignored)
-
-    pipe = do_nothing.message() | pipe_ignored.message()
-
-    with pytest.raises(ResultNotStored):
-        pipe.results
 
 
 def test_pipeline_results_can_be_retrieved(stub_broker, stub_worker, result_backend):

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -4,7 +4,6 @@ import pytest
 
 import remoulade
 from remoulade import Result
-from remoulade.errors import ResultNotStored
 from remoulade.middleware import Retries
 from remoulade.results import ErrorStored, ResultMissing, Results, ResultTimeout
 from remoulade.results.backend import FailureResult
@@ -38,28 +37,6 @@ def test_actors_can_store_results(stub_broker, stub_worker, result_backend, forg
 
     # Then the result should be what the actor returned
     assert result == 42
-
-
-def test_cannot_get_result_of_message_without_store_results(stub_broker, stub_worker, result_backend):
-    # Given a result backend
-    # And a broker with the results middleware
-    stub_broker.add_middleware(Results(backend=result_backend))
-
-    # And an actor that does not store results
-    @remoulade.actor()
-    def do_work():
-        return 42
-
-    # And this actor is declared
-    stub_broker.declare_actor(do_work)
-
-    # When I send that actor a message
-    message = do_work.send()
-
-    # I cannot access the result property of the message
-    with pytest.raises(ResultNotStored) as e:
-        message.result
-    assert str(e.value) == 'There cannot be any result to an actor without store_results=True'
 
 
 @pytest.mark.parametrize("forget", [True, False])


### PR DESCRIPTION
It was raising an error when trying to access result of message with
store_results stored at the meddleware level. No nice solution for now.
Maybe if params are stored at broker level.

fix #66