### PR TITLE
fix(groups-pipeline): store group message_ids in backend

### DIFF
--- a/remoulade/cancel/backend.py
+++ b/remoulade/cancel/backend.py
@@ -29,7 +29,7 @@ class CancelBackend:
     def __init__(self, *, cancellation_ttl=None):
         self.cancellation_ttl = cancellation_ttl or DEFAULT_CANCELLATION_TTL
 
-    def is_canceled(self, message_id: str) -> bool:
+    def is_canceled(self, message_id: str, group_id: str) -> bool:
         """ Return true if the message has been canceled """
         raise NotImplementedError("%(classname)r does not implement is_canceled" % {
             "classname": type(self).__name__,

--- a/remoulade/cancel/backends/stub.py
+++ b/remoulade/cancel/backends/stub.py
@@ -32,8 +32,11 @@ class StubBackend(CancelBackend):
         super().__init__(cancellation_ttl=cancellation_ttl)
         self.cancellations = {}
 
-    def is_canceled(self, message_id: str) -> bool:
-        return self.cancellations.get(message_id, -float('inf')) > time.time() - self.cancellation_ttl
+    def is_canceled(self, message_id: str, group_id: str) -> bool:
+        return any(
+            self.cancellations.get(key, -float('inf')) > time.time() - self.cancellation_ttl
+            for key in [message_id, group_id] if key
+        )
 
     def cancel(self, message_ids: Iterable[str]) -> None:
         timestamp = time.time()

--- a/remoulade/cancel/middleware.py
+++ b/remoulade/cancel/middleware.py
@@ -66,7 +66,9 @@ class Cancel(Middleware):
         self.backend = backend
 
     def before_process_message(self, broker, message):
-        if self.backend.is_canceled(message.message_id):
+        group_id = message.options.get("group_info", {}).get("group_id")
+
+        if self.backend.is_canceled(message.message_id, group_id):
             raise MessageCanceled("Message %s has been canceled" % message.message_id)
 
     def after_process_message(self, broker, message, *, result=None, exception=None):
@@ -82,4 +84,4 @@ class Cancel(Middleware):
 
         group_info = GroupInfo(**group_info)
         if group_info.cancel_on_error:
-            self.backend.cancel(group_info.message_ids)
+            self.backend.cancel([group_info.group_id])

--- a/remoulade/middleware/middleware.py
+++ b/remoulade/middleware/middleware.py
@@ -156,3 +156,6 @@ class Middleware:
 
     def after_enqueue_pipe_target(self, broker, group_info):
         """ Called after the pipe target of a message has been enqueued """
+
+    def before_build_group_pipeline(self, broker, group_id, message_ids):
+        """ Called before a group in a group pipeline is enqueued"""

--- a/remoulade/results/__init__.py
+++ b/remoulade/results/__init__.py
@@ -16,8 +16,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from .backend import FailureResult, Missing, ResultBackend
-from .errors import ErrorStored, ResultError, ResultMissing, ResultTimeout
+from .errors import ErrorStored, MessageIdsMissing, ResultError, ResultMissing, ResultTimeout
 from .middleware import Results
 
 __all__ = ["ErrorStored", "Missing", "ResultBackend", "FailureResult", "ResultError", "ResultTimeout",
-           "ResultMissing", "Results"]
+           "ResultMissing", "Results", "MessageIdsMissing"]

--- a/remoulade/results/backends/local.py
+++ b/remoulade/results/backends/local.py
@@ -29,6 +29,9 @@ class LocalBackend(ResultBackend):
         for (message_key, result) in zip(message_keys, results):
             self.results[message_key] = result
 
+    def _delete(self, key: str):
+        del self.results[key]
+
     def increment_group_completion(self, group_id: str) -> int:
         group_completion_key = self.build_group_completion_key(group_id)
         completion = self.results.get(group_completion_key, 0) + 1

--- a/remoulade/results/backends/stub.py
+++ b/remoulade/results/backends/stub.py
@@ -49,6 +49,9 @@ class StubBackend(ResultBackend):
             expiration = time.monotonic() + int(ttl / 1000)
             self.results[message_key] = (result_data, expiration)
 
+    def _delete(self, key: str):
+        del self.results[key]
+
     def increment_group_completion(self, group_id: str) -> int:
         group_completion_key = self.build_group_completion_key(group_id)
         completion = self.results.get(group_completion_key, 0) + 1

--- a/remoulade/results/errors.py
+++ b/remoulade/results/errors.py
@@ -41,3 +41,8 @@ class ErrorStored(ResultError):
 class ParentFailed(ResultError):
     """Error stored when a parent actor in the pipeline failed
     """
+
+
+class MessageIdsMissing(ResultError):
+    """Raised when message_ids linked to a group_id can't be found
+    """

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -50,7 +50,7 @@ def test_cancellations_not_stored_forever(cancel_backend):
     cancel_backend.cancel('c')
 
     # the first cancellation should have been forgotten
-    assert not cancel_backend.is_canceled('a')
+    assert not cancel_backend.is_canceled('a', None)
 
 
 def test_group_are_canceled_on_actor_failure(stub_broker, stub_worker, cancel_backend):
@@ -78,7 +78,7 @@ def test_group_are_canceled_on_actor_failure(stub_broker, stub_worker, cancel_ba
     stub_worker.join()
 
     # All actors should have been canceled
-    assert all(cancel_backend.is_canceled(child.message_id) for child in g.children)
+    assert all(cancel_backend.is_canceled(child.message_id, g.group_id) for child in g.children)
 
 
 def test_cannot_cancel_on_error_if_no_cancel(stub_broker):
@@ -123,5 +123,5 @@ def test_cancel_pipeline_or_groups(stub_broker, stub_worker, cancel_backend, wit
     stub_worker.join()
 
     # All actors should have been canceled
-    assert all(cancel_backend.is_canceled(child.message_id) for child in g.children)
+    assert all(cancel_backend.is_canceled(child.message_id, None) for child in g.children)
     assert len(has_been_called) == 0


### PR DESCRIPTION
previously each message of a group was containing all of the ids of
the others messages of the group. This was not scalable, and cause
memory error in RabbitMQ for big groups.

fix #79