### PR TITLE
fix(composition): Pipeline build is consistent

### DIFF
--- a/remoulade/composition.py
+++ b/remoulade/composition.py
@@ -82,14 +82,14 @@ class pipeline:
         next_child = None
         for child in reversed(self.children):
             if next_child:
-                if isinstance(next_child, list):
-                    options = {'pipe_target': [m.asdict() for m in next_child]}
-                else:
-                    options = {'pipe_target': next_child.asdict()}
+                options = {'pipe_target': [m.asdict() for m in next_child]}
             else:
                 options = last_options or {}
 
-            next_child = child.build(options)
+            if isinstance(child, group) or isinstance(child, pipeline):
+                next_child = child.build(options)
+            else:
+                next_child = [child.build(options)]
 
         return next_child
 
@@ -205,8 +205,7 @@ class group:
         messages = []
         for group_child in self.children:
             if isinstance(group_child, pipeline):
-                first = group_child.build(last_options=options)
-                messages += [first]
+                messages += group_child.build(last_options=options)
             else:
                 messages += [group_child.build(options)]
         return messages

--- a/remoulade/helpers/__init__.py
+++ b/remoulade/helpers/__init__.py
@@ -1,0 +1,19 @@
+# This file is a part of Remoulade.
+#
+# Copyright (C) 2017,2018 WIREMIND SAS <dev@wiremind.fr>
+#
+# Remoulade is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# Remoulade is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from .reduce import reduce
+
+__all__ = ["reduce"]

--- a/remoulade/helpers/reduce.py
+++ b/remoulade/helpers/reduce.py
@@ -1,0 +1,47 @@
+# This file is a part of Remoulade.
+#
+# Copyright (C) 2017,2018 WIREMIND SAS <dev@wiremind.fr>
+#
+# Remoulade is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# Remoulade is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from ..composition import group
+
+
+def reduce(messages, merge_actor, cancel_on_error=False, **kwargs):
+    """Recursively merge messages
+
+    Parameters:
+      messages(Iterator[Message|pipeline]): A sequence of messages or pipelines that needs to be merged.
+      merge_actor(Actor): The actor that will be responsible for the merge of two messages.
+      cancel_on_error(boolean): True if you want to cancel all messages of a group if one of
+        the actor fails, this is only possible with a Cancel middleware.
+      **kwargs: kwargs to be passed to each merge message.
+
+    Returns:
+      Message|pipeline: a message or a pipeline that will return the reduced result of all the given messages.
+
+    Raise:
+        NoCancelBackend: if no cancel middleware is set
+    """
+    messages = list(messages)
+    while len(messages) > 1:
+        reduced_messages = []
+        for i in range(0, len(messages), 2):
+            if i == len(messages) - 1:
+                reduced_messages.append(messages[i])
+            else:
+                grouped_message = group(messages[i:i + 2], cancel_on_error=cancel_on_error)
+                reduced_messages.append(grouped_message | merge_actor.message(**kwargs))
+        messages = reduced_messages
+
+    return messages[0]

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,8 @@ setup(
         "remoulade.results",
         "remoulade.results.backends",
         "remoulade.scheduler",
-        "remoulade.cli"
+        "remoulade.cli",
+        "remoulade.helpers"
     ],
     include_package_data=True,
     install_requires=dependencies,

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -27,12 +27,19 @@ def test_messages_can_be_piped(stub_broker):
         return {key: value for (key, value) in message.items() if key != 'options'}
 
     # If I build a pipeline
-    first_target = pipe.build()
+    targets = pipe.build()
+    assert len(targets) == 1
+    first_target = targets[0]
+    assert len(first_target.options["pipe_target"]) == 1
     # And each message in the pipeline should reference the next message in line
-    assert filter_options(first_target.options["pipe_target"]) == filter_options(pipe.children[1].asdict())
-    second_target = first_target.options["pipe_target"]
-    assert filter_options(second_target["options"]["pipe_target"]) == filter_options(pipe.children[2].asdict())
-    third_target = second_target["options"]["pipe_target"]
+    assert filter_options(first_target.options["pipe_target"][0]) == filter_options(pipe.children[1].asdict())
+
+    assert len(first_target.options["pipe_target"]) == 1
+    second_target = first_target.options["pipe_target"][0]
+    assert filter_options(second_target["options"]["pipe_target"][0]) == filter_options(pipe.children[2].asdict())
+
+    assert len(second_target["options"]["pipe_target"]) == 1
+    third_target = second_target["options"]["pipe_target"][0]
     assert "pipe_target" not in third_target["options"]
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,30 @@
+import remoulade
+from remoulade.helpers import reduce
+from remoulade.results import Results
+
+
+def test_reduce_messages(stub_broker, stub_worker, result_backend):
+    # Given a result backend
+    # And a broker with the results middleware
+    stub_broker.add_middleware(Results(backend=result_backend))
+
+    # Given an actor that stores results
+    @remoulade.actor(store_results=True)
+    def do_work():
+        return 1
+
+    # Given an actor that stores results
+    @remoulade.actor(store_results=True)
+    def merge(results):
+        return sum(results)
+
+    # And this actor is declared
+    stub_broker.declare_actor(do_work)
+    stub_broker.declare_actor(merge)
+
+    merged_message = reduce((do_work.message() for _ in range(10)), merge)
+    merged_message.run()
+
+    result = merged_message.result.get(block=True)
+
+    assert 10 == result


### PR DESCRIPTION
Pipeline built would return either a message or a list of message based
on the type of its first child. Now it always build to a list of
messages.

This means that the pipe_targets are always a list of messages.