### PR TITLE
chore: use hset instead of hmset as the former is deprecated starting from Redis 4.0.0 and redis-py 3.5.0

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -24,6 +24,8 @@ Added
 
 Changed
 ^^^^^^^
+* ``hmset`` to ``hset`` in class |RedisBackend| as the former is deprecated, this requires at least Redis 4.0.0 and
+at least redis-py 3.5.0
 * Method ``api`` ``get_states`` now 
     - can receive arguments
        * ``search_value``

--- a/remoulade/state/backends/redis.py
+++ b/remoulade/state/backends/redis.py
@@ -39,7 +39,7 @@ class RedisBackend(StateBackend):
         message_key = self._build_message_key(state.message_id)
         with self.client.pipeline() as pipe:
             encoded_state = self._encode_dict(state.as_dict())
-            pipe.hmset(message_key, encoded_state)
+            pipe.hset(message_key, mapping=encoded_state)
             pipe.expire(message_key, ttl)
             pipe.execute()
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ dependencies = ["prometheus-client>=0.2", "pytz<=2019.1", "python-dateutil>=2.8.
 
 extra_dependencies = {
     "rabbitmq": ["amqpstorm>=2.6,<3",],
-    "redis": ["redis>=3.0.1,<4.0",],
+    "redis": ["redis>=3.5.0,<4.0",],
     "watch": ["watchdog>=0.8,<0.9", "watchdog_gevent==0.1",],
     "server": ["flask>=1.1,<2", "marshmallow>=3"],
 }


### PR DESCRIPTION
- To avoid the numerous DeprecationWarning logs.
- I don't know if you want to add it to `Unreleased` as this requires  changing the lower bound of redis-py.