### PR TITLE
Fix relative import from watcher in __main__.py.

### DIFF
--- a/remoulade/__main__.py
+++ b/remoulade/__main__.py
@@ -33,7 +33,7 @@ from typing import Dict
 from remoulade import Worker, __version__, get_broker, get_logger
 
 try:
-    from .watcher import setup_file_watcher
+    from remoulade.watcher import setup_file_watcher
 
     HAS_WATCHDOG = True
 except ImportError:  # pragma: no cover


### PR DESCRIPTION
## Problem
```
[...]$ remoulade -p 2 -t 1 --watch . core
...
remoulade: error: unrecognized arguments: --watch
```
## Cause
```
[...]$ ipython
Python 3.8.5 (default, Jul 27 2020, 08:42:51) 
...
In [1]: from .watcher import setup_file_watcher
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-9983af38bb16> in <module>
----> 1 from .watcher import setup_file_watcher

ImportError: attempted relative import with no known parent package
```
## Solution
See https://stackoverflow.com/questions/16981921/relative-imports-in-python-3

