### PR TITLE
refactor: import ABCs from collections.abc

### DIFF
--- a/remoulade/common.py
+++ b/remoulade/common.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import uuid
-from collections import Iterable
+from collections.abc import Iterable
 from itertools import islice
 from queue import Empty
 from time import time


### PR DESCRIPTION
ABCs are not part from collections module since Python 3.3 and importing
from this module will not work in version 3.10.