### PR TITLE
feat: allow to use already set signal handlers in workers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10.0]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10.0]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     services:
       redis:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,22 +6,23 @@ By adding your name to the list below you disavow any rights or claims
 to any changes submitted to the Remoulade project and assign copyright
 of those changes to CLEARTYPE SRL.
 
-| Username | Name |
-| :------- | :--- |
-| [@bendemaree](https://github.com/bendemaree) | Ben Demaree |
-| [@whalesalad](https://github.com/whalesalad) | Michael Whalen |
-| [@rakanalh](https://github.com/rakanalh) | Rakan Alhneiti |
-| [@jssuzanne](https://github.com/jssuzanne) | Jean-Sébastien Suzanne |
-| [@chen2aaron](https://github.com/chen2aaron) | xixijun |
-| [@aequitas](https://github.com/aequitas) | Johan Bloemberg |
-| [@najamansari](https://github.com/najamansari) | Najam Ahmed Ansari |
-| [@rpkilby](https://github.com/rpkilby) | Ryan P Kilby |
-| [@2miksyn](https://github.com/2miksyn) | Mikhail Smirnov |
-| [@gdvalle](https://github.com/gdvalle) | Greg Dallavalle |
-| [@viiicky](https://github.com/viiicky) | Vikas Prasad |
-| [@xdmiodz](https://github.com/xdmiodz) | Dmitry Odzerikho |
-| [@ryansm1](https://github.com/ryansm1) | Ryan Smith |
-| [@aericson](https://github.com/aericson) | André Ericson |
-| [@xdanielsb](https://github.com/xdanielsb) | Daniel Santos |
-| [@simondosda](https://github.com/simondosda) | Simon Dosda |
-| [@ben-natan](https://github.com/ben-natan) | Adrien Bennatan |
+| Username                                       | Name                   |
+|:-----------------------------------------------|:-----------------------|
+| [@bendemaree](https://github.com/bendemaree)   | Ben Demaree            |
+| [@whalesalad](https://github.com/whalesalad)   | Michael Whalen         |
+| [@rakanalh](https://github.com/rakanalh)       | Rakan Alhneiti         |
+| [@jssuzanne](https://github.com/jssuzanne)     | Jean-Sébastien Suzanne |
+| [@chen2aaron](https://github.com/chen2aaron)   | xixijun                |
+| [@aequitas](https://github.com/aequitas)       | Johan Bloemberg        |
+| [@najamansari](https://github.com/najamansari) | Najam Ahmed Ansari     |
+| [@rpkilby](https://github.com/rpkilby)         | Ryan P Kilby           |
+| [@2miksyn](https://github.com/2miksyn)         | Mikhail Smirnov        |
+| [@gdvalle](https://github.com/gdvalle)         | Greg Dallavalle        |
+| [@viiicky](https://github.com/viiicky)         | Vikas Prasad           |
+| [@xdmiodz](https://github.com/xdmiodz)         | Dmitry Odzerikho       |
+| [@ryansm1](https://github.com/ryansm1)         | Ryan Smith             |
+| [@aericson](https://github.com/aericson)       | André Ericson          |
+| [@xdanielsb](https://github.com/xdanielsb)     | Daniel Santos          |
+| [@simondosda](https://github.com/simondosda)   | Simon Dosda            |
+| [@ben-natan](https://github.com/ben-natan)     | Adrien Bennatan        |
+| [@Corentin-Br](https://github.com/Corentin-Br) | Corentin Bravo         |

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+`0.55.0`_ -- 2022-08-10
+-----------------------
+Added
+^^^^^
+* result: add an async_get method
+* state/backend: add an async_get_result method on ResultBackend
 
 `0.54.2`_ -- 2022-08-10
 -----------------------

--- a/remoulade/helpers/backoff.py
+++ b/remoulade/helpers/backoff.py
@@ -81,7 +81,7 @@ def compute_backoff_exponential(attempts: int, *, min_backoff: int, max_backoff:
       int: The backoff in milliseconds.
     """
     exponent = min(attempts, max_retries - 1)
-    backoff = min(min_backoff * 2 ** exponent, max_backoff)
+    backoff = min(min_backoff * 2**exponent, max_backoff)
     return backoff
 
 

--- a/remoulade/state/backends/stub.py
+++ b/remoulade/state/backends/stub.py
@@ -15,7 +15,7 @@ class StubBackend(StateBackend):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.states = {}  # type: Dict[str, Dict[str, str]]
+        self.states: Dict[str, Dict[str, str]] = {}
 
     def get_state(self, message_id):
         message_key = self._build_message_key(message_id)
@@ -73,14 +73,14 @@ class StubBackend(StateBackend):
         return states[offset : size + offset]
 
     def get_states_count(
-            self,
-            *,
-            selected_actors: Optional[List[str]] = None,
-            selected_statuses: Optional[List[str]] = None,
-            selected_messages_ids: Optional[List[str]] = None,
-            selected_composition_ids: Optional[List[str]] = None,
-            start_datetime: Optional[datetime.datetime] = None,
-            end_datetime: Optional[datetime.datetime] = None,
-            **kwargs,
+        self,
+        *,
+        selected_actors: Optional[List[str]] = None,
+        selected_statuses: Optional[List[str]] = None,
+        selected_messages_ids: Optional[List[str]] = None,
+        selected_composition_ids: Optional[List[str]] = None,
+        start_datetime: Optional[datetime.datetime] = None,
+        end_datetime: Optional[datetime.datetime] = None,
+        **kwargs,
     ) -> int:
         return len(self.states)

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ max-line-length = 120
 max-complexity = 20
 max-line-length = 120
 select = C,E,F,W,B,B9
-ignore = E402,E501,F403,F811,E203,E231,W503
+ignore = E402,E501,F403,F811,E203,E231,W503,B905,B907
 
 inline-quotes = "
 multiline-quotes = """

--- a/tests/state/test_progress_message.py
+++ b/tests/state/test_progress_message.py
@@ -13,7 +13,7 @@ class TestProgressMessage:
     progress of the message"""
 
     def test_set_progress_message(self, stub_broker, stub_worker, state_middleware):
-        progress_messages = {}  # type: Dict[str, float]
+        progress_messages: Dict[str, float] = {}
 
         @remoulade.actor
         def do_work():

--- a/tests/test_window_rate_limiter.py
+++ b/tests/test_window_rate_limiter.py
@@ -9,7 +9,7 @@ from remoulade.rate_limits import WindowRateLimiter
 def test_window_rate_limiter_limits_per_window(rate_limiter_backend):
     # Given that I have a bucket rate limiter and a call database
     limiter = WindowRateLimiter(rate_limiter_backend, "window-test", limit=2, window=1)
-    calls = defaultdict(lambda: 0)  # type: Dict[int, int]
+    calls: Dict[int, int] = defaultdict(lambda: 0)
 
     # And a function that increments keys over the span of 3 seconds
     def work():


### PR DESCRIPTION
start_worker sets its own signal on SIGTERM, SIGINT and SIGHUP. It prevents a user from using their own signals. 
This PR allows to keep signals.