### PR TITLE
feat: enhance the type system.

### DIFF
--- a/remoulade/api/main.py
+++ b/remoulade/api/main.py
@@ -1,6 +1,6 @@
 """ This file describe the API to get the state of messages """
 import sys
-from typing import List
+from typing import Any, List
 
 from flask import Flask
 from flask_apispec import marshal_with
@@ -113,7 +113,7 @@ def get_results(message_id):
 
     max_size = 1e4
     try:
-        result = Result(message_id=message_id).get()
+        result = Result[Any](message_id=message_id).get()
         encoded_result = get_encoder().encode(result).decode("utf-8")
         size_result = sys.getsizeof(encoded_result)
         if size_result >= max_size:

--- a/remoulade/broker.py
+++ b/remoulade/broker.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from contextlib import contextmanager
 from queue import Queue
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Set, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Type, TypeVar, Union
 
 from .cancel import Cancel, CancelBackend
 from .errors import ActorNotFound, NoCancelBackend, NoResultBackend, NoStateBackend
@@ -359,7 +359,7 @@ class Broker:
     def _enqueue(self, message: "Message", *, delay: Optional[int] = None) -> "Message":
         raise NotImplementedError
 
-    def enqueue(self, message: "Message", *, delay: Optional[int] = None) -> "Message":  # pragma: no cover
+    def enqueue(self, message: "Message[Any]", *, delay: Optional[int] = None) -> "Message[Any]":  # pragma: no cover
         """Enqueue a message on this broker.
 
         Parameters:

--- a/remoulade/cancel/backend.py
+++ b/remoulade/cancel/backend.py
@@ -30,7 +30,7 @@ class CancelBackend:
     def __init__(self, *, cancellation_ttl: Optional[int] = None) -> None:
         self.cancellation_ttl = cancellation_ttl or DEFAULT_CANCELLATION_TTL
 
-    def is_canceled(self, message_id: str, composition_id: str) -> bool:
+    def is_canceled(self, message_id: str, composition_id: Optional[str]) -> bool:
         """Return true if the message has been canceled"""
         raise NotImplementedError(f"{type(self).__name__!r} does not implement is_canceled")
 

--- a/remoulade/cancel/backends/redis.py
+++ b/remoulade/cancel/backends/redis.py
@@ -61,7 +61,7 @@ class RedisBackend(CancelBackend):
         self.key = key
         self.client = client or redis.Redis(**parameters)
 
-    def is_canceled(self, message_id: str, composition_id: str) -> bool:
+    def is_canceled(self, message_id: str, composition_id: Optional[str]) -> bool:
         try:
             with self.client.pipeline() as pipe:
                 [pipe.zscore(self.key, key) for key in [message_id, composition_id] if key]

--- a/remoulade/middleware/catch_error.py
+++ b/remoulade/middleware/catch_error.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from .middleware import Middleware
 
 
@@ -21,7 +23,7 @@ class CatchError(Middleware):
                 actor = broker.get_actor(on_failure)
                 actor.send(message.actor_name, type(exception).__name__, message.args, message.kwargs)
             elif isinstance(on_failure, dict):
-                on_failure_message = Message(**on_failure)
+                on_failure_message = Message[Any](**on_failure)
                 on_failure_message = on_failure_message.copy(
                     args=[message.actor_name, type(exception).__name__, message.args, message.kwargs]
                 )

--- a/remoulade/middleware/current_message.py
+++ b/remoulade/middleware/current_message.py
@@ -3,7 +3,7 @@
 # Based in current_message.py from the dramatiq project
 
 from threading import local
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from .middleware import Middleware
 
@@ -12,11 +12,10 @@ if TYPE_CHECKING:
 
 
 class CurrentMessage(Middleware):
-
     local_data = local()
 
     @classmethod
-    def get_current_message(cls) -> Optional["Message"]:
+    def get_current_message(cls) -> Optional["Message[Any]"]:
         """Get the message that triggered the current actor.  Messages
         are thread local so this returns ``None`` when called outside
         of actor code.

--- a/remoulade/middleware/pipelines.py
+++ b/remoulade/middleware/pipelines.py
@@ -14,6 +14,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from typing import Any
+
 from ..errors import NoResultBackend
 from ..logging import get_logger
 from ..results import Results
@@ -101,7 +103,7 @@ class Pipelines(Middleware):
         from ..message import Message
 
         for message_data in pipe_target:
-            next_message = Message(**message_data)
+            next_message = Message[Any](**message_data)
             pipe_ignore = self.get_option("pipe_ignore", broker=broker, message=next_message, default=False)
 
             if not pipe_ignore:

--- a/remoulade/results/backend.py
+++ b/remoulade/results/backend.py
@@ -94,7 +94,7 @@ class ResultBackend:
         timeout: int = None,
         forget: bool = False,
         raise_on_error: bool = True,
-    ) -> BackendResult:
+    ) -> Any:
         """Get a result from the backend.
 
         Parameters:

--- a/remoulade/results/middleware.py
+++ b/remoulade/results/middleware.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from typing import Set
+from typing import Any, Set
 
 from ..logging import get_logger
 from ..middleware import Middleware
@@ -126,7 +126,7 @@ class Results(Middleware):
             for message_data in pipe_target:
                 message_ids |= self._get_children_message_ids(broker, message_data)
         elif pipe_target:
-            message = Message(**pipe_target)
+            message = Message[Any](**pipe_target)
             if self.get_option("store_results", broker=broker, message=message):
                 message_ids.add(message.message_id)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,10 @@ from unittest.mock import Mock
 import pytest
 import redis
 from freezegun import freeze_time
-from sqlalchemy import inspect
+from sqlalchemy.engine import create_engine
+from sqlalchemy.inspection import inspect
+from sqlalchemy.orm.session import sessionmaker
+from sqlalchemy.pool import NullPool
 
 import remoulade
 from remoulade import Worker
@@ -212,7 +215,7 @@ def stub_state_backend():
 @pytest.fixture
 def postgres_state_backend():
     db_string = os.getenv("REMOULADE_TEST_DB_URL") or "postgresql://remoulade@localhost:5544/test"
-    backend = st_backends.PostgresBackend(url=db_string, future=True)
+    backend = st_backends.PostgresBackend(client=sessionmaker(create_engine(db_string, poolclass=NullPool)))
     backend.clean()
     return backend
 

--- a/tests/mypy/mypy.ini
+++ b/tests/mypy/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+follow_imports=silent

--- a/tests/mypy/plain_files/actor.py
+++ b/tests/mypy/plain_files/actor.py
@@ -1,0 +1,25 @@
+from remoulade import actor
+
+
+@actor(store_results=True)
+def add(x: int, y: int = 0) -> int:
+    return x + y
+
+
+@actor
+def div(x: int, y: int) -> float:
+    return x / y
+
+
+reveal_type(add)
+reveal_type(div)
+
+# OK
+y = add(x=1, y=2)
+reveal_type(y)
+add(1, y=2)
+add(1, 2)
+add(1)
+
+# NOK
+add("s")

--- a/tests/mypy/plain_files/composition.py
+++ b/tests/mypy/plain_files/composition.py
@@ -1,0 +1,45 @@
+from typing import Any
+
+from remoulade import actor, group, pipeline
+
+
+@actor(store_results=True)
+def add(x: int, y: int) -> int:
+    return x + y
+
+
+@actor(store_results=True)
+def _print(x: str) -> None:
+    print(x)
+
+
+@actor(store_results=True)
+def stop(x: Any) -> None:
+    return
+
+
+# simple homogeneous group # both pyright and mypy can infer  that this will yield integers
+reveal_type(group([add.message(1, x) for x in range(10)]).results.get())
+# heterogeneous group # both pyright and mypy can infer  that this will yield integeror None items
+reveal_type(group([add.message(1, 2), _print.message("hello")]).results.get())
+
+# simple pipeline # both pyright and mypy can infer  that this will return an int
+reveal_type(pipeline((add.message(1, 2), add.message(1))).result.get())
+# pipeline with a bunch of different actors
+# pyright can infer  that this will return Result[None]
+# mypy in its development version can do the same
+# but current stable version infers this as <nothing>
+reveal_type(pipeline((_print.message("a"), _print.message(), stop.message())).result)
+# pipeline that ends with a group of actors
+# pyright can infer this yields integers, mypy infers this yields Any. It is not as good, but we still get the fact this is a generator, which is nice.
+pipe = pipeline(
+    (
+        add.message(1, 2),
+        group([add.message(1, 2), add.message(1, 2)]),
+    )
+)
+reveal_type(pipe.result.get())
+
+# group with pipeline that ends with a group
+# this is starting to be a very complex object, both pyright and mypy infer this as Any generator.
+reveal_type(group([pipe]).results.get())

--- a/tests/mypy/plain_files/message.py
+++ b/tests/mypy/plain_files/message.py
@@ -1,0 +1,9 @@
+from remoulade import actor
+
+
+@actor(store_results=True)
+def add(x: int, y: int) -> int:
+    return x + y
+
+
+reveal_type(add.message(1, 2))

--- a/tests/mypy/plain_files/result.py
+++ b/tests/mypy/plain_files/result.py
@@ -1,0 +1,11 @@
+from remoulade import actor
+
+
+@actor(store_results=True)
+def add(x: int, y: int) -> int:
+    return x + y
+
+
+reveal_type(add.send(1, 2).result.get())
+reveal_type(add.send(1, 2).result.get(raise_on_error=True))
+reveal_type(add.send(1, 2).result.get(raise_on_error=False))

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -1,0 +1,58 @@
+import pathlib
+
+from mypy import api
+
+
+def check_mypy_output(fname, expected_output):
+    mypy_dir = pathlib.Path(__file__).parent.resolve()
+    result = api.run([str(mypy_dir / "plain_files" / f"{fname}.py"), "--config-file", str(mypy_dir / "mypy.ini")])
+
+    assert [line for line in result[0].split("\n") if "error: " in line or "note: " in line] == expected_output, str(
+        result
+    )
+
+
+def test_actor():
+    check_mypy_output(
+        "actor",
+        [
+            'tests/mypy/plain_files/actor.py:14: note: Revealed type is "remoulade.actor.Actor[[x: builtins.int, y: builtins.int =], builtins.int]"',
+            'tests/mypy/plain_files/actor.py:15: note: Revealed type is "remoulade.actor.Actor[[x: builtins.int, y: builtins.int], builtins.float]"',
+            'tests/mypy/plain_files/actor.py:19: note: Revealed type is "builtins.int"',
+            'tests/mypy/plain_files/actor.py:25: error: Argument 1 to "__call__" of "Actor" has incompatible type "str"; expected "int"  [arg-type]',
+        ],
+    )
+
+
+def test_message():
+    check_mypy_output(
+        "message",
+        [
+            'tests/mypy/plain_files/message.py:9: note: Revealed type is "remoulade.message.Message[remoulade.result.Result[builtins.int]]"'
+        ],
+    )
+
+
+def test_result():
+    check_mypy_output(
+        "result",
+        [
+            'tests/mypy/plain_files/result.py:9: note: Revealed type is "builtins.int"',
+            'tests/mypy/plain_files/result.py:10: note: Revealed type is "builtins.int"',
+            'tests/mypy/plain_files/result.py:11: note: Revealed type is "Union[builtins.int, remoulade.results.errors.ErrorStored]"',
+        ],
+    )
+
+
+def test_group():
+    check_mypy_output(
+        "composition",
+        [
+            'tests/mypy/plain_files/composition.py:22: note: Revealed type is "typing.Generator[builtins.int, None, None]"',
+            'tests/mypy/plain_files/composition.py:24: note: Revealed type is "typing.Generator[Union[builtins.int, None], None, None]"',
+            'tests/mypy/plain_files/composition.py:27: note: Revealed type is "builtins.int"',
+            'tests/mypy/plain_files/composition.py:32: note: Revealed type is "<nothing>"',
+            'tests/mypy/plain_files/composition.py:41: note: Revealed type is "typing.Generator[Any, None, None]"',
+            'tests/mypy/plain_files/composition.py:45: note: Revealed type is "typing.Generator[Any, None, None]"',
+        ],
+    )


### PR DESCRIPTION
Breaking changes
------------------
* The only runtime breaking change is that `Message` and `Result` are no longer named tuples, but attrs frozen classes. Other breaking changes only concern the typing system.
* `Actor` is no longer a generic of the function it wraps, but it uses PEP 612 parameter specification variables. 

```python
   @actor
   def add(a: int, b: int) -> int:
      return a + b

   # previously `add` was Actor[Callable[[int, int], int]]
   # now it's Actor[[int, int], int]
   # and Actor[Callable[..., int]] becomes Actor[..., int]
```

We'll elaborate on the benefits of this approach later.

Many classes become generic:

* `Message` is now generic of the result that it generates.
* `Result` is now generic of the value that it holds.
* `CollectionResult` is now generic of the type of the child values that it contains
* `pipeline` is generic of the type of the result of the last item in the pipeline
* `group` is generic of the type of the result of its children

```python

   @actor
   def add(a: int, b: int) -> int:
      return a + b

   add.message(1, 2)  # This is now Message[Result[int]]
   add.message(1, 2).result  # this is now Result[int]
   pipeline(message(1, 2), message(1))  # this is now pipeline[Result[int]]
   group(message(1, 2), message(1))  # this is now group[Result[int]]
```
* pipeline now expects to receive a `tuple` as an input. It used to only expect an iterable. At runtime, passing a list will still work but it will generate errors if you use a type checker. The benefits of this approach will be explained below.

Enhancements of the type system
----------------------------------

The changes presented above allow us to have various enhancements in the type system:

* previously calling an actor synchronously could be made without any typechecking on the args ans kwargs passed to it. This is no longer possible and the args and kwargs passed are expected to the be the same as the ones defined in the underlying function.

```python

   @actor
   def add(a: int, b: int) -> int:
      return a + b

   add(1, "2")  # this is now an error
```

* Type checkers can now infer the type of the result of a single message, a group or a pipeline. 

```python

   @actor(store_results=True)
   def add(x: int, y: int) -> int:
      return x + y


   @actor(store_results=True)
   def _print(x: str) -> None:
      print(x)


   @actor(store_results=True)
   def stop(x: Any) -> None:
      return


   result = add.message(1, 2).result.get()  # inferred type is Result[int]
   # inferred type is Generator[int, None, None]
   results = group([add.message(1, x) for x in range(10)]).results.get()
   # It also works if tasks are heterogeneous. Inferred type here is Generator[Union[int, None], None, None]
   results = group([add.message(1, 2), _print.message("hello")]).results.get()
   # inferred type is int
   result = pipeline((add.message(1, 2), add.message(1))).result.get()
   # This works even with complex pipelines
   # pyright can infer  that this will return Result[None]
   # mypy in its development version can do the same
   # but current stable version infers this as Never
   reveal_type(pipeline((_print.message("a"), _print.message(), stop.message())).result)
```