### PR TITLE
chore(actions): fix dockerize step

### DIFF
--- a/examples/composition/Dockerfile
+++ b/examples/composition/Dockerfile
@@ -2,9 +2,11 @@
 
 FROM python:3.10
 
+WORKDIR /usr/src/app
+
 COPY . .
 RUN pip install -e .[all]
 RUN pip install -e examples/composition
 
-WORKDIR /examples/composition
+WORKDIR /usr/src/app/examples/composition
 CMD composition_worker


### PR DESCRIPTION
The problem was due to the existence of a `bin` file at the root of the python image.
Solved by working in `/usr/src/app` folder