### PR TITLE
chore(redis): bumb from 4.5 to 5.0

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,13 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+`3.1.2`_ -- 2023-11-29
+----------------------
+Chore
+^^^^^
+* redis: bumb from 4.5 to 5.0
+
+
 `3.1.1`_ -- 2023-11-10
 ----------------------
 Fix

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ dependencies = ["prometheus-client>=0.2", "pytz", "python-dateutil>=2.8.0", "typ
 
 extra_dependencies = {
     "rabbitmq": ["amqpstorm>=2.6,<3"],
-    "redis": ["redis~=4.5"],
+    "redis": ["redis~=5.0"],
     "server": ["flask>=1.1,~=2.3.3", "marshmallow>=3", "flask-apispec"],
     "postgres": ["sqlalchemy>=1.4.29,<2", "psycopg2==2.9.5"],
     "pydantic": ["pydantic>=2.0", "simplejson"],


### PR DESCRIPTION
see: https://github.com/redis/redis-py/releases/tag/v5.0.0