### PR TITLE
Update TimeLimit exit delay default

### DIFF
--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -288,10 +288,10 @@ specifying the ``time_limit`` (in milliseconds) of each one::
    For more information, see the section on :ref:`message-interrupts`.
 
 .. note::
-   If time limit fail to stop the execution via |TimeLimitExceeded| (see warning),
-   a SIGKILL will be sent to the worker after 10 seconds (by default).
-   This delay can be set with the ``sigkill_delay`` of |TimeLimit|,
-   or feature can be disabled by setting ``sigkill_delay`` to ``None``.
+   If a time limit fails to stop the execution via |TimeLimitExceeded| (see
+   warning), the worker will exit after 60 seconds by default.  This delay can be
+   adjusted with the ``exit_delay`` option of |TimeLimit| or disabled entirely by
+   setting ``exit_delay`` to ``None``.
 
 
 Handling Time Limits

--- a/remoulade/middleware/time_limit.py
+++ b/remoulade/middleware/time_limit.py
@@ -48,11 +48,13 @@ class TimeLimit(Middleware):
     Parameters:
       time_limit(int): The maximum number of milliseconds actors may run for.
       interval(int): The interval (in milliseconds) with which to check for actors that have exceeded the limit.
-      exit_delay(int): The delay (in milliseconds) after with we stop (SystemExit) to the worker if the exception failed
-       to stop the message (ie. system calls). None to disable, disabled by default.
+      exit_delay(int): The delay (in milliseconds) after which a ``SystemExit`` is
+       raised in the worker if the interrupt failed to stop the message (for
+       example while in a system call). ``None`` disables this behaviour.  The
+       default is ``60000`` (60 seconds).
     """
 
-    def __init__(self, *, time_limit: int = 1800000, interval: int = 1000, exit_delay: Optional[int] = None) -> None:
+    def __init__(self, *, time_limit: int = 1800000, interval: int = 1000, exit_delay: Optional[int] = 60000) -> None:
         self.logger = get_logger(__name__, type(self))
         self.time_limit = time_limit
         self.interval = interval


### PR DESCRIPTION
## Summary
- make `TimeLimit` exit after 60 seconds by default
- update documentation for the new `exit_delay` behaviour

## Testing
- `python -m pytest tests/test_broker.py::test_middleware_is_inserted_correctly -q` *(fails: No module named pytest)*