### PR TITLE
fix: support gevent monkey.patch_all queue patching

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -189,6 +189,9 @@ If your tasks spend most of their time doing network IO and don't
 depend on C extensions to execute those network calls then using
 gevent could provide a significant performance improvement.
 
+Remoulade supports running under ``monkey.patch_all()`` with recent
+gevent versions, including the default queue monkey-patching behavior.
+
 I suggest at least experimenting with it to see if it fits your use
 case.
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+`5.0.1`_ -- 2026-03-02
+-----------
+Fix
+^^^
+* Support gevent monkey.patch_all queue patching
+
 `5.0.0`_ -- 2026-01-09
 ------------
 Feat

--- a/remoulade/helpers/queues.py
+++ b/remoulade/helpers/queues.py
@@ -22,16 +22,33 @@ def join_queue(queue, timeout=None):
     with optional timeout support, by depending the internals of
     Queue.
 
+    It also supports gevent queue objects (for example when
+    ``monkey.patch_all(queue=True)`` is enabled), which expose
+    ``join(timeout=...)``.
+
     Raises:
       QueueJoinTimeout: When the timeout is reached.
 
     Parameters:
       timeout(Optional[float])
     """
+    # gevent compatibility: gevent queues expose join(timeout=...) while
+    # stdlib queues expose all_tasks_done.
+    if not hasattr(queue, "all_tasks_done"):
+        if timeout is None:
+            queue.join()
+            return
+
+        timeout = max(timeout, 0)
+        if queue.join(timeout=timeout) is False:
+            raise QueueJoinTimeout(f"timed out after {timeout:.2f} seconds")
+        return
+
     with queue.all_tasks_done:
         while queue.unfinished_tasks:
             finished_in_time = queue.all_tasks_done.wait(timeout=timeout)
             if not finished_in_time:
+                timeout = 0 if timeout is None else timeout
                 raise QueueJoinTimeout(f"timed out after {timeout:.2f} seconds")
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,13 @@
+import threading
+import time
+from queue import Queue
+
+import pytest
+
 import remoulade
+from remoulade import QueueJoinTimeout
 from remoulade.helpers import compute_backoff, get_actor_arguments
+from remoulade.helpers.queues import join_queue
 from remoulade.helpers.reduce import reduce
 from remoulade.results import Results
 
@@ -77,3 +85,49 @@ def test_compute_backoff_spread_exponential():
     assert compute_backoff(
         4, min_backoff=10, jitter=False, max_backoff=160, max_retries=3, backoff_strategy="spread_exponential"
     ) == (5, 160)
+
+
+class _GeventStyleQueue:
+    def __init__(self, result):
+        self.result = result
+        self.received_timeout = None
+
+    def join(self, timeout=None):
+        self.received_timeout = timeout
+        return self.result
+
+
+def test_join_queue_gevent_style_timeout_raises_queue_join_timeout():
+    queue = _GeventStyleQueue(result=False)
+
+    with pytest.raises(QueueJoinTimeout):
+        join_queue(queue, timeout=0.1)
+
+
+def test_join_queue_gevent_style_success():
+    queue = _GeventStyleQueue(result=True)
+    join_queue(queue, timeout=0.1)
+    assert queue.received_timeout == 0.1
+
+
+def test_join_queue_stdlib_fallback_success():
+    queue = Queue()
+    queue.put(1)
+
+    def worker():
+        _ = queue.get()
+        time.sleep(0.01)
+        queue.task_done()
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    join_queue(queue, timeout=0.2)
+    thread.join()
+
+
+def test_join_queue_stdlib_fallback_timeout_raises_queue_join_timeout():
+    queue = Queue()
+    queue.put(1)
+
+    with pytest.raises(QueueJoinTimeout):
+        join_queue(queue, timeout=0.01)


### PR DESCRIPTION
# The problem

We are currently unable to upgrade gevent because our code references all_tasks_done, an undocumented internal attribute of the standard library's queue.Queue.

While this attribute exists in the CPython source, it is not part of the official public API. The gevent maintainers have explicitly stated they will only support documented features of the queue module to maintain cross-version compatibility.

Failed Line: [remoulade/helpers/queues.py#L33](https://www.google.com/search?q=%5Bhttps://github.com/wiremind/remoulade/blob/19e3b2a41451de8149192201b845947397c3a7b8/remoulade/helpers/queues.py%23L33%5D(https://github.com/wiremind/remoulade/blob/19e3b2a41451de8149192201b845947397c3a7b8/remoulade/helpers/queues.py%23L33))

Upstream Discussion: [gevent Issue #2099](https://github.com/gevent/gevent/issues/2099)

# The fix

Gevent queue support .join with timeout so we can use it. If we don't have access to the Python all_tasks_done we fallback to gevent code.