### PR TITLE
feat(heartbeat): spawn a HTTP server to check liveness instead of files

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,13 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+=======
+Unreleased
+-------------
+Feat
+^^^^
+* Replace the file-based heartbeat middleware with an HTTP liveness server backed by in-memory worker heartbeats
+
 `6.1.0`_ -- 2026-05-15
 ------------
 Changed

--- a/remoulade/middleware/heartbeat.py
+++ b/remoulade/middleware/heartbeat.py
@@ -14,71 +14,139 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import os
-import tempfile
 import threading
 import time
+from functools import partial
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlsplit
 
 from ..logging import get_logger
 from .middleware import Middleware
 
+DEFAULT_HTTP_HOST = "0.0.0.0"  # noqa: S104
+DEFAULT_HTTP_PORT = 9192
+DEFAULT_THRESHOLD = 2 * 60 * 60
+HEARTBEAT_INTERVAL = 10
+
+
+class HeartbeatRequestHandler(BaseHTTPRequestHandler):
+    server: "HeartbeatServer"
+
+    def do_GET(self):
+        self.server.answer(self)
+
+    def log_message(self, *_args):
+        return
+
+
+class HeartbeatServer(HTTPServer):
+    allow_reuse_address = True
+
+    def __init__(
+        self,
+        heartbeat: "Heartbeat",
+        *,
+        http_host: str = DEFAULT_HTTP_HOST,
+        http_port: int = DEFAULT_HTTP_PORT,
+    ):
+        self.heartbeat = heartbeat
+        super().__init__((http_host, http_port), HeartbeatRequestHandler)
+
+    def answer(self, handler: BaseHTTPRequestHandler):
+        try:
+            raw_threshold = parse_qs(urlsplit(handler.path).query).get("threshold", [None])[-1]
+            threshold = self.heartbeat.threshold if raw_threshold is None else int(raw_threshold)
+            status = HTTPStatus.OK if self.heartbeat.healthy(threshold) else HTTPStatus.INTERNAL_SERVER_ERROR
+        except Exception:
+            # Probe failures must not kill the process by mistake. The worker
+            # will remain observable through logs while liveness stays green.
+            self.heartbeat.logger.exception("Heartbeat probe failed.")
+            status = HTTPStatus.OK
+
+        body = b"OK\n" if status == HTTPStatus.OK else b"UNHEALTHY\n"
+        handler.send_response(status)
+        handler.send_header("Content-Type", "text/plain; charset=utf-8")
+        handler.send_header("Content-Length", str(len(body)))
+        handler.end_headers()
+        handler.wfile.write(body)
+
 
 class Heartbeat(Middleware):
-    """Make Remoulade's heart beats.
+    """Expose worker-thread liveness over HTTP.
 
-    This middleware makes each worker thread writes a file
-    in the specified directory containing the timestamp they started their latest task.
-    You can specify a minimal interval in seconds (default to 1 minute) between each write.
-    The directory is created when starting if it does not exist
-    (default to your temporary directory+/remouladebeat).
+    A lightweight HTTP server runs alongside the worker process and reports
+    whether all worker threads have published a recent heartbeat. Heartbeats
+    are kept in memory and refreshed by worker-thread hooks.
 
-    You should use an out-of-process probe to check the beats and react in consequence
-    if the threads lock themselves.
+    Parameters:
+      http_host(str): The host to bind the heartbeat server on.
+      http_port(int): The port on which the server should listen.
+      threshold(int): The default liveness threshold, in seconds, used
+        when the request query string does not override it.
     """
 
-    class ThreadBeat(threading.local):
-        ts: float
-        file: str
-
-    # This implementation is rather simple and naive.
-    # There is nothing to ensure the actual state of the filesystem corresponds
-    # to what we think about it here.
-    # In particular, if something is killed unexpectedly, some files may be left
-    # and you could think that a thread is stuck because a file is not updated anymore.
-
-    def __init__(self, directory: str | None = None, interval: int = 60):
+    def __init__(
+        self,
+        *,
+        http_host: str = DEFAULT_HTTP_HOST,
+        http_port: int = DEFAULT_HTTP_PORT,
+        threshold: int = DEFAULT_THRESHOLD,
+    ):
         super().__init__()
-        self.basedir = directory
-        self.interval = interval
-        self.log = get_logger(__name__, "HeartbeatMiddleware")
-        # thread-specific
-        self.beat = Heartbeat.ThreadBeat()
+        self.logger = get_logger(__name__, "HeartbeatMiddleware")
+        self.threshold = threshold
+        self.local = threading.local()
+        self.heartbeats: dict[int, float] = {}
+        self.lock = threading.Lock()
+        # Defer socket binding to worker boot so producer-only processes can
+        # share the same broker configuration without claiming the port.
+        self.server_factory = partial(HeartbeatServer, self, http_host=http_host, http_port=http_port)
 
-    def after_process_boot(self, broker):
-        if not self.basedir:
-            self.basedir = tempfile.gettempdir() + "/remouladebeat"
-        os.makedirs(self.basedir, exist_ok=True)
-        self.log.debug("Created directory %s", self.basedir)
+    def healthy(self, threshold: int) -> bool:
+        if threshold <= 0:
+            raise ValueError("Heartbeat threshold must be strictly positive.")
+
+        now = time.time()
+        with self.lock:
+            heartbeats = list(self.heartbeats.values())
+        return bool(heartbeats) and all(heartbeat + threshold >= now for heartbeat in heartbeats)
+
+    def before_worker_boot(self, broker, worker):
+        self.server = self.server_factory()
+        self.server_thread = threading.Thread(target=self.server.serve_forever, name="HeartbeatServer", daemon=True)
+        self.server_thread.start()
 
     def after_worker_thread_boot(self, broker, thread):
-        fd, self.beat.file = tempfile.mkstemp(dir=self.basedir, prefix=f"th-{thread.ident}-")
-        os.close(fd)
-        self.beat.ts = 0
+        now = time.time()
+        self.local.last_beat = now
+        with self.lock:
+            self.heartbeats[thread.ident] = now
 
-    def heartbeat(self):
-        if self.beat.ts + self.interval < (beat := time.time()):
-            with open(self.beat.file, "w") as f:
-                f.write(f"{beat}")
-            self.beat.ts = beat
+    def beat(self, *, now: float | None = None):
+        now = time.time() if now is None else now
+        # Worker hooks run on every processed message and empty poll. Debounce
+        # heartbeat publication to keep locking off the hot path.
+        if self.local.last_beat + HEARTBEAT_INTERVAL > now:
+            return
+
+        self.local.last_beat = now
+        with self.lock:
+            self.heartbeats[threading.get_ident()] = now
 
     def before_process_message(self, broker, message):
-        self.heartbeat()
+        self.beat()
 
     def after_worker_thread_empty(self, broker, thread):
-        self.heartbeat()
+        self.beat()
 
     def before_worker_thread_shutdown(self, broker, thread):
-        try:
-            os.remove(self.beat.file)
-        except FileNotFoundError:
-            pass
+        with self.lock:
+            self.heartbeats.pop(thread.ident, None)
+
+    def after_worker_shutdown(self, broker, worker):
+        self.server.shutdown()
+        self.server.server_close()
+        self.server_thread.join(timeout=1)
+        with self.lock:
+            self.heartbeats.clear()

--- a/tests/middleware/test_heartbeat.py
+++ b/tests/middleware/test_heartbeat.py
@@ -14,9 +14,15 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import contextlib
+import logging
+import threading
 import time
-from pathlib import Path
+from datetime import timedelta
+from unittest import mock
+from urllib import error, request
 
+import pytest
 from freezegun import freeze_time
 
 from remoulade.brokers.stub import StubBroker
@@ -24,74 +30,166 @@ from remoulade.middleware import Heartbeat
 from remoulade.worker import Worker
 
 
-def test_heartbeat(stub_broker: StubBroker, do_work, tmp_path: Path):
-    beatdir = tmp_path
-    stub_broker.add_middleware(Heartbeat(directory=str(beatdir), interval=1))
-    stub_broker.emit_after("process_boot")
-    worker = Worker(stub_broker, worker_timeout=100, worker_threads=1)
+def _build_url(heartbeat: Heartbeat, query: str = "") -> str:
+    suffix = f"?{query}" if query else ""
+    return f"http://127.0.0.1:{heartbeat.server.server_port}/{suffix}"
+
+
+def _get_status(url: str) -> int:
+    try:
+        with request.urlopen(url, timeout=1) as response:  # noqa: S310
+            return response.getcode()
+    except error.HTTPError as exc:
+        return exc.code
+
+
+def _wait_for_threads(heartbeat: Heartbeat, count: int, timeout: float = 1) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with heartbeat.lock:
+            if len(heartbeat.heartbeats) == count:
+                return
+        time.sleep(0.01)
+    raise AssertionError(f"Timed out waiting for {count} heartbeat threads.")
+
+
+def _wait_for_response(url: str, timeout: float = 1) -> int:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            return _get_status(url)
+        except error.URLError:
+            time.sleep(0.01)
+    return _get_status(url)
+
+
+@contextlib.contextmanager
+def _heartbeat(**kwargs):
+    heartbeat = Heartbeat(http_port=0, **kwargs)
+    try:
+        yield heartbeat
+    finally:
+        with contextlib.suppress(Exception):
+            heartbeat.server.server_close()
+
+
+@contextlib.contextmanager
+def _running_worker(stub_broker: StubBroker, heartbeat: Heartbeat, *, worker_threads: int = 1):
+    stub_broker.add_middleware(heartbeat)
+    worker = Worker(stub_broker, worker_timeout=100, worker_threads=worker_threads)
     worker.start()
-    with freeze_time("1998-07-12 21:00"):
-        do_work.send()
-        stub_broker.join(do_work.queue_name)
-        worker.join()
-
-    assert beatdir.is_dir()
-    # one thread file
-    assert len(list(beatdir.iterdir())) == 1
-    beatfile = next(beatdir.iterdir())
-    beat = float(beatfile.read_text())
-
-    with freeze_time("1998-07-12 21:00"):
-        do_work.send()
-        stub_broker.join(do_work.queue_name)
-        worker.join()
-    assert float(beatfile.read_text()) == beat
-
-    with freeze_time("1998-07-12 21:27"):
-        do_work.send()
-        stub_broker.join(do_work.queue_name)
-        worker.join()
-    assert (beat2 := float(beatfile.read_text())) > beat
-
-    # Test it beats even if the queue is empty
-    with freeze_time("1998-07-12 23:00"):
-        time.sleep(2)
-    assert float(beatfile.read_text()) > beat2
-
-    worker.workers[0].stop()
-    worker.workers[0].join()
-    assert not beatfile.is_file()
-    worker.stop()
+    _wait_for_threads(heartbeat, worker_threads)
+    _wait_for_response(_build_url(heartbeat))
+    try:
+        yield worker
+    finally:
+        worker.stop()
 
 
-def test_multith_heartbeat(stub_broker: StubBroker, do_work, tmp_path: Path):
-    beatdir = tmp_path
-    stub_broker.add_middleware(Heartbeat(directory=str(beatdir), interval=1))
-    stub_broker.emit_after("process_boot")
-    worker = Worker(stub_broker, worker_timeout=100, worker_threads=2)
-    worker.start()
-    t0 = worker.workers[0]
-    t1 = worker.workers[1]
-    t0.pause()
-    t0.paused_event.wait()
-    do_work.send()
-    stub_broker.join(do_work.queue_name)
-    worker.join()
+@contextlib.contextmanager
+def _running_server(stub_broker: StubBroker, heartbeat: Heartbeat):
+    worker = mock.Mock()
+    heartbeat.before_worker_boot(stub_broker, worker)
+    _wait_for_response(_build_url(heartbeat))
+    try:
+        yield
+    finally:
+        heartbeat.after_worker_shutdown(stub_broker, worker)
 
-    t1.pause()
-    t1.paused_event.wait()
-    t0.resume()
-    do_work.send()
-    stub_broker.join(do_work.queue_name)
-    worker.join()
 
-    assert beatdir.is_dir()
-    # two thread files
-    assert len(list(beatdir.iterdir())) == 2
-    assert all(float(f.read_text()) for f in beatdir.iterdir())
+def test_heartbeat_exposes_http_liveness(stub_broker: StubBroker):
+    with _heartbeat() as heartbeat, _running_worker(stub_broker, heartbeat):
+        assert _get_status(_build_url(heartbeat)) == 200
 
-    t0.stop()
-    t0.join()
-    assert not any(str(t0.ident) in str(p) for p in beatdir.iterdir())
-    assert len(list(beatdir.iterdir())) == 1
-    worker.stop()
+
+def test_heartbeat_uses_default_threshold_when_request_does_not_override_it(stub_broker: StubBroker):
+    with (
+        _heartbeat(threshold=1) as heartbeat,
+        _running_server(stub_broker, heartbeat),
+        mock.patch.object(heartbeat, "healthy", side_effect=lambda threshold: threshold == 3) as healthy,
+    ):
+        assert _get_status(_build_url(heartbeat)) == 500
+        assert _get_status(_build_url(heartbeat, "threshold=3")) == 200
+        assert healthy.call_args_list == [mock.call(1), mock.call(3)]
+
+
+def test_heartbeat_returns_500_without_any_worker_threads(stub_broker: StubBroker):
+    with _heartbeat() as heartbeat, _running_server(stub_broker, heartbeat):
+        assert _wait_for_response(_build_url(heartbeat)) == 500
+
+
+@pytest.mark.parametrize("query", ["threshold=abc", "threshold=0"])
+def test_heartbeat_logs_and_returns_200_on_invalid_threshold(
+    stub_broker: StubBroker,
+    caplog: pytest.LogCaptureFixture,
+    query: str,
+):
+    with _heartbeat() as heartbeat, _running_worker(stub_broker, heartbeat):
+        with caplog.at_level(logging.ERROR, logger="remoulade.middleware.heartbeat.HeartbeatMiddleware"):
+            assert _get_status(_build_url(heartbeat, query)) == 200
+
+        assert any(record.message == "Heartbeat probe failed." for record in caplog.records)
+
+
+def test_heartbeat_logs_and_returns_200_on_probe_exception(
+    stub_broker: StubBroker,
+    caplog: pytest.LogCaptureFixture,
+):
+    with (
+        _heartbeat() as heartbeat,
+        _running_worker(stub_broker, heartbeat),
+        mock.patch.object(heartbeat, "healthy", side_effect=RuntimeError("boom")),
+        caplog.at_level(logging.ERROR, logger="remoulade.middleware.heartbeat.HeartbeatMiddleware"),
+    ):
+        assert _get_status(_build_url(heartbeat)) == 200
+
+    assert any(record.message == "Heartbeat probe failed." for record in caplog.records)
+
+
+def test_heartbeat_server_shuts_down_cleanly(stub_broker: StubBroker):
+    with _heartbeat() as heartbeat:
+        with _running_worker(stub_broker, heartbeat):
+            url = _build_url(heartbeat)
+
+        with pytest.raises(error.URLError):
+            request.urlopen(url, timeout=1)  # noqa: S310
+
+
+def test_healthy_returns_false_when_any_worker_thread_is_stale():
+    with _heartbeat() as heartbeat, freeze_time("2020-02-03 00:00:00") as frozen_time:
+        with heartbeat.lock:
+            heartbeat.heartbeats[1] = time.time()
+        frozen_time.tick(delta=timedelta(seconds=2))
+        with heartbeat.lock:
+            heartbeat.heartbeats[2] = time.time()
+
+        assert not heartbeat.healthy(1)
+
+
+def test_healthy_returns_false_without_any_worker_threads():
+    with _heartbeat() as heartbeat:
+        assert not heartbeat.healthy(1)
+
+
+def test_healthy_raises_on_non_positive_threshold():
+    with _heartbeat() as heartbeat, pytest.raises(ValueError, match="strictly positive"):
+        heartbeat.healthy(0)
+
+
+def test_heartbeat_debounces_publication():
+    with _heartbeat() as heartbeat, freeze_time("2020-02-03 00:00:00") as frozen_time:
+        start_time = time.time()
+        heartbeat.local.last_beat = start_time
+        thread_id = threading.get_ident()
+        with heartbeat.lock:
+            heartbeat.heartbeats[thread_id] = start_time
+
+        frozen_time.tick(delta=timedelta(seconds=9))
+        heartbeat.beat()
+        with heartbeat.lock:
+            assert heartbeat.heartbeats[thread_id] == start_time
+
+        frozen_time.tick(delta=timedelta(seconds=1))
+        heartbeat.beat()
+        with heartbeat.lock:
+            assert heartbeat.heartbeats[thread_id] == time.time()


### PR DESCRIPTION
## Summary
- replace the file-based heartbeat with an in-process HTTP liveness server

