### PR TITLE
fix: make sure remoulade_message_time_in_queue_milliseconds prometheu…

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+`5.1.1`_ -- 2026-04-20
+------------
+Feat
+^^^^
+* Fix remoulade_message_time_in_queue_milliseconds prometheus metric to make sure it is monotonically increasing
+
 `5.1.0`_ -- 2026-03-03
 ------------
 Feat

--- a/remoulade/middleware/prometheus.py
+++ b/remoulade/middleware/prometheus.py
@@ -180,7 +180,7 @@ class Prometheus(Middleware):
     def before_process_message(self, broker, message):
         self.message_start_times[message.message_id] = time.monotonic() * 1000
         self.message_time_in_queue.labels(*self._get_labels(broker, message)).observe(
-            current_millis() - message.message_timestamp
+            max(current_millis() - message.message_timestamp, 0)
         )
         self.worker_busy.set(1)
 


### PR DESCRIPTION
fix: make sure remoulade_message_time_in_queue_milliseconds prometheus metric is monotonically increasing