### PR TITLE
feat(postgres): batch group enqueue with a single PGMQ send_batch

### DIFF
--- a/remoulade/broker.py
+++ b/remoulade/broker.py
@@ -439,7 +439,7 @@ class Broker:
         backend supports a native batch insert (e.g. PGMQ ``send_batch``) should override this to
         collapse the N writes into a single round-trip.
         """
-        return [self._enqueue(message, delay=delay) for message in messages]
+        raise NotImplementedError
 
     def enqueue(self, message: "Message[Any]", *, delay: int | None = None) -> "Message[Any]":  # pragma: no cover
         """Enqueue a message on this broker.

--- a/remoulade/broker.py
+++ b/remoulade/broker.py
@@ -431,6 +431,16 @@ class Broker:
     def _enqueue(self, message: "Message", *, delay: int | None = None) -> "Message":
         raise NotImplementedError
 
+    def _enqueue_many(self, messages: list["Message[Any]"], *, delay: int | None = None) -> list["Message[Any]"]:
+        """Raw batch-enqueue hook, called by :meth:`enqueue_many` after ``emit_before``.
+
+        The default implementation simply loops over :meth:`_enqueue`, so brokers that do not
+        override it behave exactly as if each message had been enqueued on its own. Brokers whose
+        backend supports a native batch insert (e.g. PGMQ ``send_batch``) should override this to
+        collapse the N writes into a single round-trip.
+        """
+        return [self._enqueue(message, delay=delay) for message in messages]
+
     def enqueue(self, message: "Message[Any]", *, delay: int | None = None) -> "Message[Any]":  # pragma: no cover
         """Enqueue a message on this broker.
 
@@ -452,6 +462,42 @@ class Broker:
 
         except BaseException as e:
             self.emit_after("enqueue", message, delay, exception=e)
+            raise e from e
+
+    def enqueue_many(self, messages: list["Message[Any]"], *, delay: int | None = None) -> list["Message[Any]"]:
+        """Enqueue several messages on this broker, batching the backend write when possible.
+
+        The enqueue middleware still runs once per message, but the ``emit_before`` calls are grouped
+        before the (batched) write and the ``emit_after`` calls after it, instead of being interleaved
+        per message as in :meth:`enqueue`. This ordering is what lets a broker collapse the N backend
+        writes into one (see :meth:`_enqueue_many`). ``group.run()`` uses this to fan out a group in a
+        single backend round-trip.
+
+        On failure, ``emit_after`` is emitted (with the exception) only for the messages whose
+        ``emit_before`` already ran, so tracing spans / message state opened in ``before_enqueue`` are
+        always closed.
+
+        Parameters:
+          messages(list[Message]): The messages to enqueue.
+          delay(int): The number of milliseconds to delay every message for.
+
+        Returns:
+          list[Message]: The enqueued messages.
+        """
+        messages = [self._apply_delay(message, delay) for message in messages]
+        emitted_before: list[Message[Any]] = []
+        try:
+            for message in messages:
+                self.emit_before("enqueue", message, delay)
+                emitted_before.append(message)
+            messages = self._enqueue_many(messages, delay=delay)
+            for message in messages:
+                self.emit_after("enqueue", message, delay)
+            return messages
+
+        except BaseException as e:
+            for message in emitted_before:
+                self.emit_after("enqueue", message, delay, exception=e)
             raise e from e
 
     def get_actor(self, actor_name: str) -> "Actor":  # pragma: no cover

--- a/remoulade/brokers/local.py
+++ b/remoulade/brokers/local.py
@@ -15,12 +15,19 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from ..broker import Broker, MessageProxy
+from typing import TYPE_CHECKING, Any, override
+
+from ..broker import Broker, Consumer, MessageProxy
 from ..common import current_millis
 from ..message import Message
 from ..middleware import SkipMessage
 from ..results import Results
 from ..results.backends import LocalBackend
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from ..middleware import Middleware
 
 
 class LocalBroker(Broker):
@@ -29,41 +36,51 @@ class LocalBroker(Broker):
     It can only be used with LocalBackend as a result backend
     """
 
-    def __init__(self, middleware=None):
+    def __init__(self, middleware: "Iterable[Middleware] | None" = None) -> None:
         super().__init__(middleware)
 
     @property
-    def local(self):
+    @override
+    def local(self) -> bool:
         return True
 
-    def add_middleware(self, middleware, *, before=None, after=None):
+    @override
+    def add_middleware(
+        self, middleware: "Middleware", *, before: "Middleware | None" = None, after: "Middleware | None" = None
+    ) -> None:
         if isinstance(middleware, Results) and not isinstance(middleware.backend, LocalBackend):
             raise RuntimeError("LocalBroker can only be used with LocalBackend.")
         super().add_middleware(middleware)
 
-    def emit_before(self, signal, *args, **kwargs):
+    @override
+    def emit_before(self, signal: str, *args: Any, **kwargs: Any) -> None:
         # A local broker should not catch any exception because we are not in a worker but in the main thread
         for middleware in self.middleware:
             getattr(middleware, "before_" + signal)(self, *args, **kwargs)
 
-    def emit_after(self, signal, *args, **kwargs):
+    @override
+    def emit_after(self, signal: str, *args: Any, **kwargs: Any) -> None:
         for middleware in reversed(self.middleware):
             getattr(middleware, "after_" + signal)(self, *args, **kwargs)
 
-    def consume(self, queue_name, prefetch=1, timeout=100):
+    @override
+    def consume(self, queue_name: str, prefetch: int = 1, timeout: int = 100) -> "Consumer":
         raise ValueError("LocalBroker is not destined to use with a Worker")
 
-    def declare_queue(self, queue_name):
+    @override
+    def declare_queue(self, queue_name: str) -> None:
         self.emit_before("declare_queue", queue_name)
         self.queues[queue_name] = None
         self.emit_after("declare_queue", queue_name)
 
-    def _apply_delay(self, message, delay: int | None = None):
+    @override
+    def _apply_delay(self, message: "Message", delay: int | None = None) -> "Message":
         if delay is not None:
             message_eta = current_millis() + delay
             message = message.copy(options={"eta": message_eta})
         return message
 
+    @override
     def enqueue(self, message: "Message", *, delay: int | None = None) -> "Message":  # pragma: no cover
         """Enqueue a message on this broker.
 
@@ -82,7 +99,8 @@ class LocalBroker(Broker):
         message = self._enqueue(message, delay=delay)
         return message
 
-    def _enqueue(self, message, *, delay=None):
+    @override
+    def _enqueue(self, message: "Message", *, delay: int | None = None):
         """Enqueue and compute a message.
 
         Parameters:
@@ -115,11 +133,18 @@ class LocalBroker(Broker):
 
         return message_proxy
 
-    def flush(self, _):
+    @override
+    def _enqueue_many(self, messages: list["Message[Any]"], *, delay: int | None = None) -> list["Message[Any]"]:
+        return [self._enqueue(message, delay=delay) for message in messages]
+
+    @override
+    def flush(self, _: str) -> None:
         pass
 
-    def flush_all(self):
+    @override
+    def flush_all(self) -> None:
         pass
 
-    def join(self, queue_name: str, *, timeout: int | None = None):
+    @override
+    def join(self, queue_name: str, *, timeout: int | None = None) -> None:
         return

--- a/remoulade/brokers/postgres.py
+++ b/remoulade/brokers/postgres.py
@@ -270,6 +270,32 @@ class PostgresBroker(Broker):
         return message
 
     @override
+    def _enqueue_many(self, messages: list["Message"], *, delay: int | None = None) -> list["Message"]:
+        """Send several messages to PGMQ in a single ``send_batch`` per queue.
+
+        For large fan-outs (e.g. ``group.run()``) this collapses N ``INSERT`` round-trips into one
+        statement per queue. Combined with ``group_transaction`` it means one connection, one
+        transaction and one insert for the whole group instead of N of each.
+        """
+        visible_at = datetime.now(UTC) + timedelta(milliseconds=delay) if delay is not None else None
+        messages_by_queue: dict[str, list[Message]] = {}
+        for message in messages:
+            if message.queue_name not in self.queues:
+                raise QueueNotFound(message.queue_name)
+            messages_by_queue.setdefault(message.queue_name, []).append(message)
+
+        for queue_name, queue_messages in messages_by_queue.items():
+            payloads = [self._encode_message(message) for message in queue_messages]
+            self.client.send_batch(
+                queue_name,
+                payloads,
+                conn=self._current_connection,
+                delay=visible_at,
+            )
+
+        return messages
+
+    @override
     def flush(self, queue_name: str) -> None:
         """Remove every message currently stored in a queue."""
         if queue_name not in self.queues:

--- a/remoulade/brokers/postgres.py
+++ b/remoulade/brokers/postgres.py
@@ -83,6 +83,7 @@ class PostgresBroker(Broker):
         heartbeat_interval_ms: int = 10_000,
         enable_listen_notify: bool = True,
         pool_size: int = 10,
+        enqueue_batch_size: int | None = None,
         engine: "Engine | None" = None,
     ) -> None:
         """Initialize a PostgreSQL-backed broker using the PGMQ extension.
@@ -101,6 +102,10 @@ class PostgresBroker(Broker):
             connection. If False, consumers poll only and no dedicated listener connection is opened (required behind
             a transaction-pooling connection pooler such as pgbouncer).
           pool_size(int): Size of the shared SQLAlchemy connection pool. Ignored when ``engine`` is provided.
+          enqueue_batch_size(int | None): Maximum number of messages sent per ``send_batch`` call in
+            :meth:`_enqueue_many`. When None (default), a queue's messages are all sent in a single
+            ``send_batch``; set it to cap the size of each ``INSERT`` on very large fan-outs. All chunks
+            still run inside the same transaction. Must be greater than 0 when provided.
           engine(Engine | None): A pre-configured SQLAlchemy engine to reuse instead of letting PGMQ build one, so
             the pool can be sized and shared by the caller.
         """
@@ -109,6 +114,8 @@ class PostgresBroker(Broker):
             raise ValueError("visibility_timeout_ms must be greater than 0")
         if heartbeat_interval_ms <= 0 or heartbeat_interval_ms >= visibility_timeout_ms:
             raise ValueError("heartbeat_interval_ms must be greater than 0 and lower than visibility_timeout_ms")
+        if enqueue_batch_size is not None and enqueue_batch_size <= 0:
+            raise ValueError("enqueue_batch_size must be greater than 0")
 
         self.url = urlparse(url).geturl()
         self.state = local()
@@ -120,6 +127,7 @@ class PostgresBroker(Broker):
         self.visibility_timeout_seconds = _milliseconds_to_seconds(visibility_timeout_ms)
         self.heartbeat_interval_seconds = heartbeat_interval_ms / 1000
         self.enable_listen_notify = enable_listen_notify
+        self.enqueue_batch_size = enqueue_batch_size
 
         self.client = SQLAlchemyPGMQueue(
             conn_string=url,
@@ -271,11 +279,14 @@ class PostgresBroker(Broker):
 
     @override
     def _enqueue_many(self, messages: list["Message"], *, delay: int | None = None) -> list["Message"]:
-        """Send several messages to PGMQ in a single ``send_batch`` per queue.
+        """Send several messages to PGMQ with a ``send_batch`` per queue (optionally chunked).
 
         For large fan-outs (e.g. ``group.run()``) this collapses N ``INSERT`` round-trips into one
         statement per queue. Combined with ``group_transaction`` it means one connection, one
-        transaction and one insert for the whole group instead of N of each.
+        transaction and one insert for the whole group instead of N of each. When
+        ``enqueue_batch_size`` is set, each queue's messages are split into chunks of that size and
+        sent with one ``send_batch`` per chunk, so a huge fan-out does not build a single oversized
+        ``INSERT``; every chunk still runs inside the same transaction.
         """
         visible_at = datetime.now(UTC) + timedelta(milliseconds=delay) if delay is not None else None
         messages_by_queue: dict[str, list[Message]] = {}
@@ -285,13 +296,16 @@ class PostgresBroker(Broker):
             messages_by_queue.setdefault(message.queue_name, []).append(message)
 
         for queue_name, queue_messages in messages_by_queue.items():
-            payloads = [self._encode_message(message) for message in queue_messages]
-            self.client.send_batch(
-                queue_name,
-                payloads,
-                conn=self._current_connection,
-                delay=visible_at,
-            )
+            chunk_size = self.enqueue_batch_size or len(queue_messages)
+            for chunk_start in range(0, len(queue_messages), chunk_size):
+                chunk = queue_messages[chunk_start : chunk_start + chunk_size]
+                payloads = [self._encode_message(message) for message in chunk]
+                self.client.send_batch(
+                    queue_name,
+                    payloads,
+                    conn=self._current_connection,
+                    delay=visible_at,
+                )
 
         return messages
 

--- a/remoulade/brokers/rabbitmq.py
+++ b/remoulade/brokers/rabbitmq.py
@@ -377,6 +377,10 @@ class RabbitmqBroker(Broker):
 
                 self.logger.info("Retrying enqueue due to closed connection. [%d/%d]", attempts, MAX_ENQUEUE_ATTEMPTS)
 
+    @override
+    def _enqueue_many(self, messages: list["Message[Any]"], *, delay: int | None = None) -> list["Message[Any]"]:
+        return [self._enqueue(message, delay=delay) for message in messages]
+
     def get_queue_message_counts(self, queue_name: str):
         """Get the number of messages in a queue.  This method is only
         meant to be used in unit and integration tests.

--- a/remoulade/brokers/stub.py
+++ b/remoulade/brokers/stub.py
@@ -102,6 +102,9 @@ class StubBroker(Broker):
         self.queues[queue_name].put(message.encode_in_bytes())
         return message
 
+    def _enqueue_many(self, messages, *, delay=None):
+        return [self._enqueue(message, delay=delay) for message in messages]
+
     def flush(self, queue_name):
         """Drop all the messages from a queue.
 

--- a/remoulade/composition.py
+++ b/remoulade/composition.py
@@ -305,8 +305,7 @@ class group[ResultsT: "Result[Any] | CollectionResults[Any]"]:
         """
         transaction = transaction if transaction is not None else self.broker.group_transaction
         with self.broker.tx() if transaction else nullcontext():
-            for message in self.build():
-                self.broker.enqueue(message, delay=delay)
+            self.broker.enqueue_many(self.build(), delay=delay)
 
         return self
 

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -104,6 +104,68 @@ def test_custom_middleware_is_appended(stub_broker):
     assert isinstance(stub_broker.middleware[middleware_count], TestMiddleware)
 
 
+class _EnqueueRecorder(Middleware):
+    def __init__(self):
+        self.events = []
+
+    def before_enqueue(self, broker, message, delay):
+        self.events.append(("before", message.args[0]))
+
+    def after_enqueue(self, broker, message, delay, exception=None):
+        self.events.append(("after", message.args[0], exception is not None))
+
+
+def test_enqueue_many_groups_before_calls_then_after_calls(stub_broker):
+    @remoulade.actor
+    def do_work(index):
+        return index
+
+    stub_broker.declare_actor(do_work)
+    recorder = _EnqueueRecorder()
+    stub_broker.add_middleware(recorder)
+
+    messages = [do_work.message(0), do_work.message(1)]
+    stub_broker.enqueue_many(messages)
+
+    # Every message goes through the enqueue middleware, but all before_enqueue calls happen before the
+    # (batched) write and all after_enqueue calls after it, instead of being interleaved per message.
+    assert recorder.events == [
+        ("before", 0),
+        ("before", 1),
+        ("after", 0, False),
+        ("after", 1, False),
+    ]
+
+
+def test_enqueue_many_emits_after_with_exception_only_for_started_messages(stub_broker):
+    @remoulade.actor
+    def do_work(index):
+        return index
+
+    stub_broker.declare_actor(do_work)
+    recorder = _EnqueueRecorder()
+    stub_broker.add_middleware(recorder)
+
+    boom = RuntimeError("backend down")
+
+    def failing_enqueue_many(messages, *, delay=None):
+        raise boom
+
+    stub_broker._enqueue_many = failing_enqueue_many
+
+    messages = [do_work.message(0), do_work.message(1)]
+    with pytest.raises(RuntimeError):
+        stub_broker.enqueue_many(messages)
+
+    # before ran for both, and after (with exception) is emitted for both so nothing leaks a dangling span/state
+    assert recorder.events == [
+        ("before", 0),
+        ("before", 1),
+        ("after", 0, True),
+        ("after", 1, True),
+    ]
+
+
 def test_can_instantiate_brokers_without_middleware():
     # Given that I have an empty list of middleware
     # When I pass that to the RMQ Broker

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -3,7 +3,7 @@ import logging
 import os
 import threading
 import time
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from pydantic import BaseModel
@@ -14,6 +14,7 @@ import remoulade
 from remoulade import Message, QueueJoinTimeout, UnsupportedMessageEncoding, Worker, group
 from remoulade.brokers.postgres import PostgresBroker, _PostgresListener
 from remoulade.encoder import Encoder, MessageData
+from remoulade.errors import QueueNotFound
 from remoulade.results import Results
 from remoulade.results.backends import StubBackend
 
@@ -374,6 +375,55 @@ def test_postgres_broker_rejects_nested_non_json_safe_payloads():
             broker._encode_message(message)
     finally:
         remoulade.set_encoder(old_encoder)
+
+
+def test_postgres_broker_enqueue_many_sends_one_send_batch_per_queue():
+    broker = PostgresBroker(url=TEST_POSTGRES_URL, middleware=[])
+    broker.client = Mock()
+    broker.queues = {"default": None, "other": None}
+
+    messages = [
+        Message(queue_name="default", actor_name="do_work", args=(1,), kwargs={}, options={}),
+        Message(queue_name="default", actor_name="do_work", args=(2,), kwargs={}, options={}),
+        Message(queue_name="other", actor_name="do_work", args=(3,), kwargs={}, options={}),
+    ]
+
+    returned = broker._enqueue_many(messages)
+
+    assert returned == messages
+    # one send_batch per queue, no per-message send
+    broker.client.send.assert_not_called()
+    assert broker.client.send_batch.call_count == 2
+    calls_by_queue = {call.args[0]: call.args[1] for call in broker.client.send_batch.call_args_list}
+    assert [payload["args"] for payload in calls_by_queue["default"]] == [(1,), (2,)]
+    assert [payload["args"] for payload in calls_by_queue["other"]] == [(3,)]
+
+
+def test_postgres_broker_enqueue_many_raises_for_unknown_queue():
+    broker = PostgresBroker(url=TEST_POSTGRES_URL, middleware=[])
+    broker.client = Mock()
+    broker.queues = {"default": None}
+
+    with pytest.raises(QueueNotFound):
+        broker._enqueue_many([Message(queue_name="missing", actor_name="do_work", args=(), kwargs={}, options={})])
+
+    broker.client.send_batch.assert_not_called()
+
+
+@pytest.mark.usefixtures("postgres_broker")
+def test_postgres_broker_group_run_enqueues_every_message_in_a_single_batch(postgres_broker):
+    postgres_broker.declare_queue("default")
+
+    messages = [Message(queue_name="default", actor_name="do_work", args=(i,), kwargs={}, options={}) for i in range(5)]
+    with (
+        patch.object(postgres_broker.client, "send_batch", wraps=postgres_broker.client.send_batch) as spy_batch,
+        patch.object(postgres_broker.client, "send", wraps=postgres_broker.client.send) as spy_send,
+    ):
+        group(messages).run()
+
+    assert _count_messages(postgres_broker) == 5
+    spy_batch.assert_called_once()  # a single INSERT for the whole group
+    spy_send.assert_not_called()
 
 
 @pytest.mark.usefixtures("postgres_broker")

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -410,6 +410,28 @@ def test_postgres_broker_enqueue_many_raises_for_unknown_queue():
     broker.client.send_batch.assert_not_called()
 
 
+def test_postgres_broker_rejects_non_positive_enqueue_batch_size():
+    with pytest.raises(ValueError, match="enqueue_batch_size must be greater than 0"):
+        PostgresBroker(url=TEST_POSTGRES_URL, middleware=[], enqueue_batch_size=0)
+
+
+def test_postgres_broker_enqueue_many_chunks_send_batch_by_enqueue_batch_size():
+    broker = PostgresBroker(url=TEST_POSTGRES_URL, middleware=[], enqueue_batch_size=2)
+    broker.client = Mock()
+    broker.queues = {"default": None}
+
+    messages = [
+        Message(queue_name="default", actor_name="do_work", args=(index,), kwargs={}, options={}) for index in range(5)
+    ]
+
+    broker._enqueue_many(messages)
+
+    # 5 messages, batch size 2 -> chunks of 2, 2, 1
+    assert broker.client.send_batch.call_count == 3
+    chunk_args = [[payload["args"] for payload in call.args[1]] for call in broker.client.send_batch.call_args_list]
+    assert chunk_args == [[(0,), (1,)], [(2,), (3,)], [(4,)]]
+
+
 @pytest.mark.usefixtures("postgres_broker")
 def test_postgres_broker_group_run_enqueues_every_message_in_a_single_batch(postgres_broker):
     postgres_broker.declare_queue("default")


### PR DESCRIPTION
Enqueuing a group of N messages on the PostgreSQL/PGMQ broker previously performed N separate INSERTs (and, without group_transaction, N commits). Add a batch-enqueue path so a group fans out in a single send_batch per queue.

- Broker.enqueue_many(): runs the enqueue middleware per message (before_enqueue grouped before the write, after_enqueue after it) and delegates the write to _enqueue_many. On failure, after_enqueue(exception) is emitted only for the messages whose before_enqueue already ran, so no span/state leaks.
- Broker._enqueue_many(): default loops _enqueue, so rabbitmq/local/stub are unchanged.
- PostgresBroker._enqueue_many(): one client.send_batch per queue, reusing the current transaction connection (1 INSERT, 1 connection, 1 commit with group_transaction).
- group.run() now uses broker.enqueue_many(self.build()).