### PR TITLE
fix(postgres): cap in-flight messages at prefetch like RabbitMQ QoS

### DIFF
--- a/remoulade/brokers/postgres.py
+++ b/remoulade/brokers/postgres.py
@@ -202,6 +202,10 @@ class PostgresBroker(Broker):
     def consume(self, queue_name: str, prefetch: int = 1, timeout: int = 30000) -> "_PostgresConsumer":
         """Create a consumer for a declared queue.
 
+        ``prefetch`` caps the number of in-flight (unacked) messages the
+        consumer may hold at any time — the same contract RabbitMQ enforces
+        server-side with ``basic_qos`` — not just the batch size per read.
+
         Raises:
           QueueNotFound: If the queue has not been declared.
         """
@@ -592,9 +596,10 @@ class _PostgresConsumer(Consumer):
         Parameters:
           broker(PostgresBroker): Broker instance that owns the queue and database client.
           queue_name(str): Name of the declared queue to consume from.
-          prefetch(int): Maximum number of messages fetched per read call; must be greater than or equal to 1.
-          timeout(int): Idle wait timeout in milliseconds when polling for messages; must be greater than or equal to 0.
-            A value of 0 performs non-blocking reads.
+          prefetch(int): Maximum number of in-flight (unacked) messages the consumer may hold, and therefore
+            also the upper bound of messages fetched per read call; must be greater than or equal to 1.
+          timeout(int): Idle wait timeout in milliseconds when polling for messages or waiting for in-flight
+            capacity; must be greater than or equal to 0. A value of 0 performs non-blocking reads.
 
         """
         if prefetch < 1:
@@ -611,6 +616,7 @@ class _PostgresConsumer(Consumer):
         self.heartbeat_interval_seconds = broker.heartbeat_interval_seconds
         self.messages: deque[PostgresQueueMessage] = deque()
         self._notify_event = Event()
+        self._capacity_event = Event()
         self._heartbeat_stop = Event()
         self._heartbeat_thread: Thread | None = None
         self._heartbeat_message_ids_lock = Lock()
@@ -638,47 +644,47 @@ class _PostgresConsumer(Consumer):
             return []
         return [messages] if not isinstance(messages, list) else messages
 
-    def _read_immediate(self) -> list[PostgresQueueMessage]:
-        """Read up to ``prefetch`` messages without polling."""
+    def _read_immediate(self, qty: int) -> list[PostgresQueueMessage]:
+        """Read up to ``qty`` messages without polling."""
         return self._normalize_messages(
             self.client.read(
                 self.queue_name,
                 vt=self.visibility_timeout_seconds,
-                qty=self.prefetch,
+                qty=qty,
             )
         )
 
-    def _read_with_poll(self) -> list[PostgresQueueMessage]:
-        """Read up to ``prefetch`` messages using PGMQ polling.
+    def _read_with_poll(self, qty: int) -> list[PostgresQueueMessage]:
+        """Read up to ``qty`` messages using PGMQ polling.
 
         A zero timeout means non-blocking: do a single immediate read instead
         of polling for the rounded-up one-second minimum.
         """
         if self.timeout == 0:
-            return self._read_immediate()
+            return self._read_immediate(qty)
         return self._normalize_messages(
             self.client.read_with_poll(
                 self.queue_name,
                 vt=self.visibility_timeout_seconds,
-                qty=self.prefetch,
+                qty=qty,
                 max_poll_seconds=max((self.timeout + 999) // 1000, 1),
                 poll_interval_ms=max(min(self.timeout, 1000), 1),
             )
         )
 
-    def _read_next_batch(self) -> list[PostgresQueueMessage]:
-        """Read the next batch, favoring LISTEN/NOTIFY when available."""
+    def _read_next_batch(self, qty: int) -> list[PostgresQueueMessage]:
+        """Read the next batch of at most ``qty`` messages, favoring LISTEN/NOTIFY when available."""
         if not self._listener_available:
-            return self._read_with_poll()
+            return self._read_with_poll(qty)
 
-        messages = self._read_immediate()
+        messages = self._read_immediate(qty)
         if messages:
             self._notify_event.clear()
             return messages
 
         self._notify_event.wait(self.wait_timeout_seconds)
         self._notify_event.clear()
-        return self._read_immediate() if self._listener_available else self._read_with_poll()
+        return self._read_immediate(qty) if self._listener_available else self._read_with_poll(qty)
 
     def _start_heartbeat(self) -> None:
         """Start the background visibility-timeout renewal thread."""
@@ -717,10 +723,16 @@ class _PostgresConsumer(Consumer):
                     exc_info=True,
                 )
 
+    def _pending_ack_count(self) -> int:
+        """Count messages read but not yet acked, nacked or requeued."""
+        with self._heartbeat_message_ids_lock:
+            return len(self._heartbeat_message_ids)
+
     def _unregister_heartbeat_message_id(self, message_id: int) -> None:
-        """Stop tracking a message for heartbeat renewal."""
+        """Stop tracking a message for heartbeat renewal and free an in-flight slot."""
         with self._heartbeat_message_ids_lock:
             self._heartbeat_message_ids.discard(message_id)
+        self._capacity_event.set()
 
     def _requeue_message_ids(self, message_ids: list[int]) -> None:
         """Make a batch of message ids visible again immediately."""
@@ -775,11 +787,22 @@ class _PostgresConsumer(Consumer):
 
     @override
     def __next__(self) -> "_PostgresMessage | None":
-        """Return the next available message, or ``None`` if the queue stays empty."""
+        """Return the next available message, or ``None`` if the queue stays empty
+        or the consumer is at its in-flight capacity."""
         if self.messages:
             return self._build_message(self.messages.popleft())
 
-        messages = self._read_next_batch()
+        # PGMQ has no server-side equivalent of RabbitMQ's basic_qos, so the
+        # in-flight cap must be enforced here: reading regardless of unacked
+        # count would drain the whole queue into worker memory and make the
+        # heartbeat renew an ever-growing set of ids.
+        capacity = self.prefetch - self._pending_ack_count()
+        if capacity <= 0:
+            self._capacity_event.wait(self.wait_timeout_seconds)
+            self._capacity_event.clear()
+            return None
+
+        messages = self._read_next_batch(capacity)
 
         if not messages:
             return None
@@ -794,6 +817,7 @@ class _PostgresConsumer(Consumer):
         """Stop the heartbeat, unregister from the shared listener and requeue buffered messages."""
         self._heartbeat_stop.set()
         self._notify_event.set()
+        self._capacity_event.set()
         if self.broker._listener is not None:
             self.broker._listener.unregister(self.queue_name, self._notify_event)
         if self._heartbeat_thread is not None:

--- a/remoulade/brokers/postgres.py
+++ b/remoulade/brokers/postgres.py
@@ -215,7 +215,13 @@ class PostgresBroker(Broker):
 
     @override
     def declare_queue(self, queue_name: str) -> None:
-        """Create a partitioned PGMQ queue if it does not already exist."""
+        """Create a partitioned PGMQ queue if it does not already exist.
+
+        Also ensures the queue table has a btree index on ``msg_id`` — even
+        for pre-existing queues, so queues created before remoulade added the
+        index pick it up on the next declaration. On a large existing queue
+        the initial index build locks the table for its duration.
+        """
         if queue_name in self.queues:
             return
         with self.tx():
@@ -238,10 +244,28 @@ class PostgresBroker(Broker):
                 if self.enable_listen_notify:
                     self._try_enable_notify(queue_name)
 
+            self._create_msg_id_index(queue_name, self._current_connection)
+
         self.queues[queue_name] = None
 
         if not queue_exists:
             self.emit_after("declare_queue", queue_name)
+
+    def _create_msg_id_index(self, queue_name: str, connection: "Connection") -> None:
+        """Ensure the queue table has a btree index on ``msg_id``.
+
+        PGMQ's time-partitioned queue tables ship without one, so every
+        ``archive`` (ack/nack) and ``set_vt`` (heartbeat, requeue) lookup seq
+        scans all partitions. Created on the partitioned parent, the index
+        propagates to existing and future partitions. ``msg_id`` never
+        changes, so the index does not defeat HOT updates of ``vt``/``read_ct``.
+
+        The queue name must already be validated (``validate_queue_name``)
+        since it is interpolated as an identifier.
+        """
+        connection.execute(
+            text(f'CREATE INDEX IF NOT EXISTS "q_{queue_name}_msg_id_idx" ON pgmq."q_{queue_name}" (msg_id)')
+        )
 
     def _encode_message(self, message: "Message") -> PostgresPayload:
         """Encode a Remoulade message into a JSON object payload for PGMQ.

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -652,6 +652,82 @@ def test_postgres_consumer_close_requeues_buffered_prefetched_messages(monkeypat
     broker.client.set_vt.assert_called_once_with("default", [2], 0)
 
 
+def test_postgres_consumer_caps_in_flight_messages_at_prefetch(monkeypatch):
+    def _fake_start_heartbeat(self):
+        self._heartbeat_thread = None
+
+    monkeypatch.setattr("remoulade.brokers.postgres._PostgresConsumer._start_heartbeat", _fake_start_heartbeat)
+
+    broker = PostgresBroker(url=TEST_POSTGRES_URL, middleware=[])
+    broker.queues["default"] = None
+    _install_listener(broker, available=False)
+
+    first_message = Message(queue_name="default", actor_name="do_work", args=(1,), kwargs={}, options={})
+    second_message = Message(queue_name="default", actor_name="do_work", args=(2,), kwargs={}, options={})
+    broker.client.read = Mock(return_value=None)
+    broker.client.read_with_poll = Mock(
+        return_value=[
+            Mock(msg_id=1, message=_expected_payload(first_message)),
+            Mock(msg_id=2, message=_expected_payload(second_message)),
+        ]
+    )
+    broker.client.set_vt = Mock()
+
+    consumer = broker.consume("default", prefetch=2, timeout=10)
+
+    assert next(consumer) is not None
+    assert next(consumer) is not None
+
+    # Both messages are unacked: the consumer is at capacity and must not
+    # read again until a slot is freed.
+    assert next(consumer) is None
+    broker.client.read_with_poll.assert_called_once()
+
+    consumer.close()
+
+
+def test_postgres_consumer_resumes_reading_when_an_ack_frees_capacity(monkeypatch):
+    def _fake_start_heartbeat(self):
+        self._heartbeat_thread = None
+
+    monkeypatch.setattr("remoulade.brokers.postgres._PostgresConsumer._start_heartbeat", _fake_start_heartbeat)
+
+    broker = PostgresBroker(url=TEST_POSTGRES_URL, middleware=[])
+    broker.queues["default"] = None
+    _install_listener(broker, available=False)
+
+    first_message = Message(queue_name="default", actor_name="do_work", args=(1,), kwargs={}, options={})
+    second_message = Message(queue_name="default", actor_name="do_work", args=(2,), kwargs={}, options={})
+    broker.client.read = Mock(return_value=None)
+    broker.client.read_with_poll = Mock(
+        side_effect=[
+            [
+                Mock(msg_id=1, message=_expected_payload(first_message)),
+                Mock(msg_id=2, message=_expected_payload(second_message)),
+            ],
+            [],
+        ]
+    )
+    broker.client.set_vt = Mock()
+    broker.client.archive = Mock()
+
+    consumer = broker.consume("default", prefetch=2, timeout=10)
+
+    first = next(consumer)
+    assert first is not None
+    assert next(consumer) is not None
+    assert next(consumer) is None  # at capacity, no read issued
+
+    consumer.ack(first)
+
+    assert next(consumer) is None  # one slot free again: reads, queue is empty
+    assert broker.client.read_with_poll.call_count == 2
+    # Only the freed slot may be requested, keeping in-flight <= prefetch.
+    assert broker.client.read_with_poll.call_args.kwargs["qty"] == 1
+
+    consumer.close()
+
+
 def test_postgres_consumer_falls_back_to_polling_when_listener_stops_during_wait():
     broker = PostgresBroker(url=TEST_POSTGRES_URL, middleware=[])
     broker.queues["default"] = None

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -190,6 +190,7 @@ def test_postgres_broker_does_not_fail_when_enable_notify_raises(caplog):
     broker.client.create_partitioned_queue = Mock()
     broker.client.enable_notify = Mock(side_effect=RuntimeError("notify unavailable"))
     broker._queue_exists = Mock(return_value=False)
+    broker._create_msg_id_index = Mock()
 
     broker.declare_queue("default")
 
@@ -203,12 +204,32 @@ def test_postgres_broker_declare_queue_is_idempotent_when_queue_already_exists()
     broker.client.create_partitioned_queue = Mock()
     broker.client.enable_notify = Mock()
     broker._queue_exists = Mock(return_value=True)
+    broker._create_msg_id_index = Mock()
 
     broker.declare_queue("default")
 
     broker.client.create_partitioned_queue.assert_not_called()
     broker.client.enable_notify.assert_not_called()
+    # The index is still ensured on pre-existing queues, so queues created
+    # before remoulade added it pick it up on the next declaration.
+    broker._create_msg_id_index.assert_called_once()
     assert "default" in broker.queues
+
+
+def test_postgres_broker_declare_queue_creates_msg_id_index():
+    broker = PostgresBroker(url=TEST_POSTGRES_URL, middleware=[])
+    broker.client.validate_queue_name = Mock()
+    broker.client.create_partitioned_queue = Mock()
+    broker.client.enable_notify = Mock()
+    broker._queue_exists = Mock(return_value=False)
+
+    conn = Mock()
+    broker.client.engine.begin = Mock(return_value=_StubTransaction(conn))
+
+    broker.declare_queue("default")
+
+    executed = [str(call.args[0]) for call in conn.execute.call_args_list]
+    assert 'CREATE INDEX IF NOT EXISTS "q_default_msg_id_idx" ON pgmq."q_default" (msg_id)' in executed
 
 
 def test_postgres_broker_poll_only_mode_opens_no_listener_and_skips_enable_notify():
@@ -217,6 +238,7 @@ def test_postgres_broker_poll_only_mode_opens_no_listener_and_skips_enable_notif
     broker.client.create_partitioned_queue = Mock()
     broker.client.enable_notify = Mock()
     broker._queue_exists = Mock(return_value=False)
+    broker._create_msg_id_index = Mock()
 
     broker.declare_queue("default")
 
@@ -806,6 +828,7 @@ def test_postgres_consumer_decodes_payload_with_global_encoder(pydantic_encoder)
     broker.client.create_partitioned_queue = Mock()
     broker.client.enable_notify = Mock()
     broker._queue_exists = Mock(return_value=False)
+    broker._create_msg_id_index = Mock()
     _install_listener(broker, available=False)
 
     @remoulade.actor(actor_name="typed.actor", queue_name="default")
@@ -888,6 +911,48 @@ def test_postgres_consumer_requeue_restores_visibility_with_set_vt(postgres_brok
     consumer.close()
 
     assert _count_messages(postgres_broker) == 0
+
+
+@pytest.mark.usefixtures("postgres_broker")
+def test_postgres_broker_declare_queue_creates_msg_id_index_on_all_partitions(postgres_broker):
+    postgres_broker.declare_queue("default")
+
+    with postgres_broker.client.session() as session:
+        tables = (
+            session.execute(
+                text(
+                    "SELECT tablename FROM pg_indexes "
+                    "WHERE schemaname = 'pgmq' AND indexdef LIKE '%USING btree (msg_id)' "
+                    "AND (tablename = 'q_default' OR tablename LIKE 'q\\_default\\_p%')"
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert "q_default" in tables  # the partitioned parent
+    assert len(tables) > 1  # propagated to at least one partition
+
+
+@pytest.mark.usefixtures("postgres_broker")
+def test_postgres_broker_declare_queue_restores_missing_msg_id_index(postgres_broker):
+    postgres_broker.declare_queue("default")
+
+    # Simulate a queue created before remoulade started ensuring the index.
+    with postgres_broker.client.engine.begin() as connection:
+        connection.execute(text('DROP INDEX pgmq."q_default_msg_id_idx"'))
+
+    postgres_broker.queues.pop("default")
+    postgres_broker.declare_queue("default")
+
+    with postgres_broker.client.session() as session:
+        index_exists = session.execute(
+            text(
+                "SELECT EXISTS(SELECT 1 FROM pg_indexes "
+                "WHERE schemaname = 'pgmq' AND indexname = 'q_default_msg_id_idx')"
+            )
+        ).scalar_one()
+    assert index_exists
 
 
 @pytest.mark.usefixtures("postgres_broker")


### PR DESCRIPTION
PGMQ has no server-side equivalent of RabbitMQ's basic_qos, so the consumer kept reading regardless of how many messages were unacked: with any backlog it drained the queue into worker memory, and the heartbeat renewed an ever-growing set of ids every 10s. The resulting giant set_vt updates bloated the queue table, serialized acks behind row locks and collapsed worker throughput until the process restarted.

Enforce prefetch as the in-flight cap in the consumer: only read when unacked count is below prefetch, only request the free slots, and wait for an ack to free a slot instead of busy-looping when at capacity.