### PR TITLE
fix(catch_error): re-stamp on_failure message so a late callback is not age-dropped

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+Unreleased
+----------
+Fixed
+^^^^^
+* ``CatchError`` now re-stamps the re-enqueued ``on_failure`` message with a fresh ``message_id`` and ``message_timestamp``. Previously a callback attached to a message that retried or aged for a long time kept its original build time, so if it carried a ``max_age`` it could be dropped by ``AgeLimit`` before running.
+
 `7.0.0`_ -- 2026-06-15
 ------------
 Breaking changes

--- a/remoulade/middleware/catch_error.py
+++ b/remoulade/middleware/catch_error.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from ..common import current_millis, generate_unique_id
 from .middleware import Middleware
 
 
@@ -25,8 +26,13 @@ class CatchError(Middleware):
                 actor.send(message.actor_name, type(exception).__name__, exception.args, message.args, message.kwargs)
             elif isinstance(on_failure, dict):
                 on_failure_message = Message[Any](**on_failure)
+                # The on_failure message may have been built long before the failure it reports (e.g. attached to a
+                # message that retried/aged for hours). Re-stamp it with a fresh id and timestamp so it is treated as
+                # freshly enqueued and cannot be dropped by AgeLimit against its original build time.
                 on_failure_message = on_failure_message.copy(
-                    args=[message.actor_name, type(exception).__name__, exception.args, message.args, message.kwargs]
+                    args=[message.actor_name, type(exception).__name__, exception.args, message.args, message.kwargs],
+                    message_id=generate_unique_id(),
+                    message_timestamp=current_millis(),
                 )
                 broker.enqueue(on_failure_message)
 

--- a/tests/middleware/test_catch_error.py
+++ b/tests/middleware/test_catch_error.py
@@ -1,6 +1,7 @@
 import time
 
 import remoulade
+from remoulade.common import current_millis
 
 
 def test_on_failure(stub_broker, stub_worker):
@@ -149,6 +150,36 @@ def test_on_failure_keeps_existing_exception_args(stub_broker, stub_worker):
     stub_worker.join()
 
     assert failure_message_kwargs == {"exception_args": ["existing-value"]}
+
+
+def test_on_failure_stale_message_is_restamped(stub_broker, stub_worker):
+    on_failure_count = 0
+
+    @remoulade.actor
+    def on_failure(actor_name, exception_name, exception_args, args, kwargs):
+        nonlocal on_failure_count
+        on_failure_count += 1
+
+    @remoulade.actor
+    def fail_actor():
+        raise Exception()
+
+    remoulade.declare_actors([on_failure, fail_actor])
+
+    # An on_failure message can be built long before the failure it reports (attached to a message that
+    # retries/ages for hours). It carries its own max_age, so if CatchError re-enqueues it with its original
+    # timestamp AgeLimit drops it before it runs. CatchError must re-stamp it so it is treated as freshly enqueued.
+    on_failure_message = on_failure.message_with_options(max_age=1000)
+    on_failure_message = on_failure_message.copy(message_timestamp=current_millis() - 10000)
+
+    fail_actor.send_with_options(on_failure=on_failure_message)
+
+    stub_broker.join(fail_actor.queue_name)
+    stub_broker.join(on_failure.queue_name)
+    stub_worker.join()
+
+    # The on_failure should still run despite the stale build time.
+    assert on_failure_count == 1
 
 
 def test_clean_runs_on_timeout(stub_broker, stub_worker):


### PR DESCRIPTION
## Problem

`CatchError.after_process_message` re-enqueues the `on_failure` message from a dict re-materialised via `Message(**on_failure).copy(...)`. `copy` (attr.evolve + option-merge) preserves the original `message_timestamp` and `message_id` — the ones from when the `on_failure` message was *built*, which can be long before the failure it reports.

When the `on_failure` message carries its own `max_age` (a common pattern for batch callbacks) and is attached to a message that retried or aged in a delay queue for hours, the re-enqueued callback is born already past its age limit. `AgeLimit.before_process_message` then drops it at consume time and the callback **never runs** — silently.

This was hit in production: a batch's ~884 hard failures escalated/retried into a delay queue overnight; when they finally failed terminally the next morning, every `on_failure` callback was enqueued with its ~13–20h-old build timestamp and immediately age-dropped into the dead-letter queue, so the downstream system was never notified.

## Fix

Re-stamp the re-enqueued `on_failure` message with a fresh `message_id` and `message_timestamp` so it is treated as freshly enqueued. This matches the string-actor-name `on_failure` path, which already builds a fresh message via `actor.send`. The callback is a leaf message (no `pipe_target`), so a fresh id is safe.

## Test

`test_on_failure_stale_message_is_restamped` reproduces the bug: an `on_failure` message with a small `max_age` and a backdated `message_timestamp` is dropped by `AgeLimit` before the fix and runs after it. Verified it fails on the pre-fix code and passes on the fixed code; full `test_catch_error.py` suite green; ruff + mypy clean.

## Notes

- Changelog: added an `Unreleased` / Fixed entry — please assign a version at tag time.
- The success-path pipe_target message (`Pipelines`) re-materialises its dict with the original timestamp too; the same staleness can affect long-backlogged pipelines. Not addressed here — flagging for a possible follow-up.