### PR TITLE
refactor: enable more `ruff` lints and enable `ty` type checker

### DIFF
--- a/.github/workflows/example-container.yml
+++ b/.github/workflows/example-container.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v7
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -33,14 +33,14 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5.0.0
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
             suffix=-example-composition
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5.0.0
+        uses: docker/build-push-action@v7
         with:
           push: true
           file: ./examples/composition/Dockerfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: ${{ matrix.python-version }}
           activate-environment: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,5 +31,5 @@ jobs:
         run: ruff check
       - name: Format with ruff
         run: ruff format --check --diff
-      - name: Check typing with mypy
-        run: mypy --show-traceback
+      - name: Check typing with ty
+        run: ty check

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -15,9 +15,9 @@ jobs:
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: "3.12"
           activate-environment: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,9 +37,9 @@ jobs:
           POSTGRES_DB: test
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: ${{ matrix.python-version }}
           activate-environment: true

--- a/.github/workflows/validate_commits.yml
+++ b/.github/workflows/validate_commits.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Commitsar check
-        uses: docker://aevea/commitsar:0.20.2
+        uses: docker://aevea/commitsar:1.0.3

--- a/.gitignore
+++ b/.gitignore
@@ -106,11 +106,6 @@ venv.bak/
 /site
 .run
 
-# mypy
-.mypy_cache/
-.dmypy.json
-dmypy.json
-
 #Others
 /.benchmarks
 /benchmark*.svg

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,19 +2,12 @@ default_language_version:
   python: python3.14
 exclude: ^env/
 repos:
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.18.2
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.65
     hooks:
-      - id: mypy
-        additional_dependencies:
-          - sqlalchemy[mypy]
-          - types-redis
-          - types-python-dateutil
-          - types-simplejson
-          - types-requests
-          - attrs
+      - id: ty
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.0
+    rev: v0.16.1
     hooks:
       - id: ruff-check
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,11 +3,11 @@ default_language_version:
 exclude: ^env/
 repos:
   - repo: https://github.com/astral-sh/ty-pre-commit
-    rev: v0.0.65
+    rev: v0.0.79
     hooks:
       - id: ty
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.1
+    rev: v0.16.6
     hooks:
       - id: ruff-check
         args:

--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -6,12 +6,12 @@ import subprocess
 import sys
 import time
 
-import celery
-import pylibmc
+import celery  # ty: ignore[unresolved-import]
+import pylibmc  # ty: ignore[unresolved-import]
 
 import remoulade
 from remoulade.brokers.rabbitmq import RabbitmqBroker
-from remoulade.brokers.redis import RedisBroker
+from remoulade.brokers.redis import RedisBroker  # ty: ignore[unresolved-import]
 
 logger = logging.getLogger("example")
 counter_key = "latench-bench-counter"

--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -137,7 +137,7 @@ def main(args):
             else:
                 subprocess_args = ["remoulade", "bench", "-p", "8"]
 
-        proc = subprocess.Popen(subprocess_args)  # noqa: S603
+        proc = subprocess.Popen(subprocess_args)  # ruff: ignore[S603]
         processed = 0
         while processed < args.count:
             processed = client.get(counter_key)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,15 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+`7.1.0`_ -- 2026-08-02
+----------------------
+Changed
+^^^^^^^
+* Replace ``mypy`` with ``ty`` for static type checking.
+* Enable additional Ruff lints and clean up legacy ignores.
+* Upgrade GitHub Actions and CI workflow dependencies.
+* Refactor internal data structures (``State`` to ``@dataclass``, helpers to ``NamedTuple``).
+
 `7.0.0`_ -- 2026-06-15
 ------------
 Breaking changes

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,15 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+`7.2.0`_ -- 2026-08-02
+----------------------
+Changed
+^^^^^^^
+* Replace ``mypy`` with ``ty`` for static type checking.
+* Enable additional Ruff lints and clean up legacy ignores.
+* Upgrade GitHub Actions and CI workflow dependencies.
+* Refactor internal data structures (``State`` to ``@dataclass``, helpers to ``NamedTuple``).
+
 `7.1.1`_ -- 2026-09-02
 ----------------------
 Fix

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@
 import os
 import sys
 
-import alabaster  # noqa
+import alabaster  # ruff: ignore[F401]
 
 import remoulade
 
@@ -66,7 +66,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Remoulade"
-copyright = "2017, CLEARTYPE SRL, WIREMIND SAS"  # noqa: A001
+copyright = "2017, CLEARTYPE SRL, WIREMIND SAS"  # ruff: ignore[A001]
 author = "CLEARTYPE SRL, WIREMIND SAS"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/examples/composition/composition/actors.py
+++ b/examples/composition/composition/actors.py
@@ -21,7 +21,7 @@ remoulade.get_broker().add_middleware(MessageState(backend=RedisStateBackend()))
 
 @remoulade.actor(store_results=True)
 def request(uri):
-    return requests.get(uri).text  # noqa: S113
+    return requests.get(uri).text  # ruff: ignore[S113]
 
 
 @remoulade.actor(store_results=True)

--- a/examples/composition/composition/serve.py
+++ b/examples/composition/composition/serve.py
@@ -3,9 +3,9 @@
 
 from remoulade.api import app
 
-from .actors import broker  # noqa: F401
+from .actors import broker  # ruff: ignore[F401]
 
 
 # Run backend API server (used for superbowl for instance)
 def serve():
-    app.run(debug=True, host="0.0.0.0", port=5000, reloader_type="stat")  # noqa: S104
+    app.run(debug=True, host="0.0.0.0", port=5000, reloader_type="stat")  # ruff: ignore[S104]

--- a/examples/composition/composition/worker.py
+++ b/examples/composition/composition/worker.py
@@ -9,7 +9,7 @@ from remoulade.middleware import Prometheus
 from .actors import broker
 
 prometheus: Middleware = Prometheus(
-    http_host="0.0.0.0",  # noqa: S104
+    http_host="0.0.0.0",  # ruff: ignore[S104]
     http_port=9191,
     registry=REGISTRY,
 )

--- a/examples/crawler/example.py
+++ b/examples/crawler/example.py
@@ -44,7 +44,7 @@ def crawl(url):
 
         for match in anchor_re.finditer(response.content):
             anchor = match.group(1).decode("utf-8")
-            if anchor.startswith("http://") or anchor.startswith("https://"):
+            if anchor.startswith(("http://", "https://")):
                 crawl.send(anchor)
                 matches += 1
 

--- a/examples/scheduling/example.py
+++ b/examples/scheduling/example.py
@@ -10,7 +10,7 @@ remoulade.set_broker(broker)
 
 @remoulade.actor()
 def count_words(url):
-    response = requests.get(url).text  # noqa: S113
+    response = requests.get(url).text  # ruff: ignore[S113]
     print(f"There are {len(response)} words in {url}")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,34 +99,33 @@ markers = ["confirm_delivery", "group_transaction"]
 [tool.ruff]
 target-version = "py312"
 line-length = 120
-exclude = [".git"]
 
 [tool.ruff.lint]
 # https://docs.astral.sh/ruff/rules/
 select = [
-  "S",    # flake8-bandit
-  "B",    # flake8-bugbear
-  "A",    # flake8-builtins
-  "C4",   # flake8-comprehensions
-  "ISC",  # flake8-implicit-str-concat
-  "G",    # flake8-logging-format
-  "PIE",  # flake8-pie
-  "PYI",  # lake8-pyi
-  "Q",    # flake8-quotes
-  "RSE",  # flake8-raise
-  "RET",  # flake8-return-ret
-  "SIM",  # flake8-simplify-sim
-  "TC",   # flake8-type-checking
-  "I",    # isort
-  "N",    # pep8-naming
-  "PERF", # perflint-perf
-  "E",    # error
-  "W",    # warning
-  "F",    # pyflakes
-  "UP",   # pyupgrade
-  "FURB", # refurb
-  "RUF",  # ruff-specific-rules
-  "ANN401",
+  "S",      # flake8-bandit
+  "B",      # flake8-bugbear
+  "A",      # flake8-builtins
+  "C4",     # flake8-comprehensions
+  "ISC",    # flake8-implicit-str-concat
+  "G",      # flake8-logging-format
+  "PIE",    # flake8-pie
+  "PYI",    # lake8-pyi
+  "Q",      # flake8-quotes
+  "RSE",    # flake8-raise
+  "RET",    # flake8-return-ret
+  "SIM",    # flake8-simplify-sim
+  "TC",     # flake8-type-checking
+  "I",      # isort
+  "N",      # pep8-naming
+  "PERF",   # perflint-perf
+  "E",      # error
+  "W",      # warning
+  "F",      # pyflakes
+  "UP",     # pyupgrade
+  "FURB",   # refurb
+  "RUF",    # ruff-specific-rules
+  "ANN401", # any-type
 ]
 ignore = [
   "N801",
@@ -135,9 +134,6 @@ ignore = [
   "S403",
   "S404",
   "S405",
-  # try-except-pass
-  "PYI033",
-  "SIM105",
   "RUF067",
   "RUF106",
   "RUF201",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,7 @@ dev = [
   "sphinx-copybutton",
   # Linting
   "ruff",
-  "mypy~=1.18.2",
-  "sqlalchemy[mypy]>=2.0,<3",
+  "ty",
   "types-redis",
   "types-python-dateutil",
   "types-requests",
@@ -100,7 +99,7 @@ markers = ["confirm_delivery", "group_transaction"]
 [tool.ruff]
 target-version = "py312"
 line-length = 120
-exclude = [".git", "tests/mypy"]
+exclude = [".git"]
 
 [tool.ruff.lint]
 # https://docs.astral.sh/ruff/rules/
@@ -151,23 +150,5 @@ combine-as-imports = true
 force-wrap-aliases = true
 known-first-party = ["remoulade"]
 
-[tool.mypy]
-python_version = "3.12"
-ignore_missing_imports = true
-check_untyped_defs = true
-warn_unused_ignores = true
-strict_optional = false
-plugins = ["sqlalchemy.ext.mypy.plugin"]
-files = ["remoulade/**/*.py", "tests/**/*.py"]
-
-[[tool.mypy.overrides]]
-module = ["remoulade.scheduler.*"]
-ignore_errors = true
-
-[[tool.mypy.overrides]]
-module = ["benchmarks.*"]
-ignore_errors = true
-
-[[tool.mypy.overrides]]
-module = ["tests.*"]
-ignore_errors = true
+[tool.ty.environment]
+python-version = "3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,8 +110,14 @@ select = [
   "A",    # flake8-builtins
   "C4",   # flake8-comprehensions
   "ISC",  # flake8-implicit-str-concat
+  "G",    # flake8-logging-format
+  "PIE",  # flake8-pie
+  "PYI",  # lake8-pyi
   "Q",    # flake8-quotes
+  "RSE",  # flake8-raise
+  "RET",  # flake8-return-ret
   "SIM",  # flake8-simplify-sim
+  "TC",   # flake8-type-checking
   "I",    # isort
   "N",    # pep8-naming
   "PERF", # perflint-perf
@@ -119,14 +125,22 @@ select = [
   "W",    # warning
   "F",    # pyflakes
   "UP",   # pyupgrade
+  "FURB", # refurb
   "RUF",  # ruff-specific-rules
 ]
 ignore = [
   "N801",
   "N818",
   "S311",
+  "S403",
+  "S404",
+  "S405",
   # try-except-pass
-  "SIM105"
+  "PYI033",
+  "SIM105",
+  "RUF067",
+  "RUF106",
+  "RUF201",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ select = [
   "UP",   # pyupgrade
   "FURB", # refurb
   "RUF",  # ruff-specific-rules
+  "ANN401",
 ]
 ignore = [
   "N801",

--- a/remoulade/__init__.py
+++ b/remoulade/__init__.py
@@ -27,7 +27,7 @@ from .errors import (
     BrokerError,
     ChannelPoolTimeout,
     ConnectionClosed,
-    ConnectionError,  # noqa: A004
+    ConnectionError,  # ruff: ignore[A004]
     ConnectionFailed,
     NoResultBackend,
     QueueJoinTimeout,
@@ -92,4 +92,4 @@ __all__ = [
     "set_scheduler",
 ]
 
-__version__ = importlib.metadata.version(__package__)
+__version__ = importlib.metadata.version(__package__ or "remoulade")

--- a/remoulade/__main__.py
+++ b/remoulade/__main__.py
@@ -21,6 +21,7 @@ import contextlib
 import importlib
 import logging
 import os
+import pathlib
 import signal
 import sys
 import time
@@ -100,7 +101,7 @@ def parse_arguments():
     )
     parser.add_argument(
         "--log-file",
-        type=argparse.FileType(mode="a", encoding="utf-8"),
+        type=str,
         help="write all logs to a file (default: sys.stderr)",
     )
     parser.add_argument(
@@ -117,11 +118,10 @@ def parse_arguments():
 def setup_pidfile(filename):
     try:
         pid = os.getpid()
-        with open(filename) as pid_file:
-            old_pid = int(pid_file.read().strip())
-            # This can happen when reloading the process via SIGHUP.
-            if old_pid == pid:
-                return pid
+        old_pid = int(pathlib.Path(filename).read_text().strip())
+        # This can happen when reloading the process via SIGHUP.
+        if old_pid == pid:
+            return pid
 
         try:
             os.kill(old_pid, 0)
@@ -139,8 +139,7 @@ def setup_pidfile(filename):
         raise RuntimeError("PID file contains garbage. Aborting.") from e
 
     try:
-        with open(filename, "w") as pid_file:
-            pid_file.write(str(pid))
+        pathlib.Path(filename).write_text(str(pid))
 
         # Change permissions to -rw-r--r--.
         os.chmod(filename, 0o644)
@@ -157,9 +156,14 @@ def remove_pidfile(filename, logger):
         logger.debug("Failed to remove PID file. It's gone.")
 
 
-def setup_logging(args, *, stream=sys.stderr):
+def setup_logging(args, *, stream=None):
     level = verbosity.get(args.verbose, logging.DEBUG)
-    logging.basicConfig(level=level, format=logformat, stream=stream)
+    if stream is not None:
+        logging.basicConfig(level=level, format=logformat, stream=stream)
+    elif args.log_file:
+        logging.basicConfig(level=level, format=logformat, filename=args.log_file, filemode="a", encoding="utf-8")
+    else:
+        logging.basicConfig(level=level, format=logformat, stream=sys.stderr)
     return get_logger("remoulade")
 
 
@@ -186,7 +190,7 @@ def start_worker(args, logger):
             running = False
         else:
             logger.warning("Killing worker...")
-            return os._exit(RET_KILLED)
+            os._exit(RET_KILLED)
 
     logger.info("Worker is ready for action.")
     signal.signal(signal.SIGINT, termhandler)
@@ -221,12 +225,12 @@ def main():
         if args.pid_file:
             setup_pidfile(args.pid_file)
     except RuntimeError as e:
-        logger = setup_logging(args, stream=args.log_file or sys.stderr)
+        logger = setup_logging(args)
         logger.critical(e)
         return RET_PIDFILE
 
-    logger = setup_logging(args, stream=args.log_file or sys.stderr)
-    logger.info(f"Remoulade {__version__!r} is booting up.")
+    logger = setup_logging(args)
+    logger.info("Remoulade %r is booting up.", __version__)
     if args.pid_file:
         atexit.register(remove_pidfile, args.pid_file, logger)
 

--- a/remoulade/__main__.py
+++ b/remoulade/__main__.py
@@ -184,7 +184,7 @@ def start_worker(args, logger):
         return os._exit(RET_IMPORT)
 
     def termhandler(signum, frame):
-        nonlocal running  # type: ignore
+        nonlocal running
         if running:
             logger.info("Stopping worker...")
             running = False

--- a/remoulade/actor.py
+++ b/remoulade/actor.py
@@ -17,7 +17,7 @@
 
 import re
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Literal, ParamSpec, TypedDict, TypeVar, overload
+from typing import TYPE_CHECKING, Any, ParamSpec, TypedDict, TypeVar, overload
 
 from .helpers.actor_arguments import get_actor_arguments
 from .logging import get_logger
@@ -45,7 +45,7 @@ class ActorDict(TypedDict):
 
 @overload
 def actor(
-    fn: Literal[None] = None,
+    fn: None = None,
     *,
     actor_name: str | None = None,
     queue_name: str = "default",
@@ -122,7 +122,7 @@ def actor(
 
     def decorator(fn: Callable[P, R]) -> Actor[P, R]:
         nonlocal actor_name
-        actor_name = actor_name or fn.__name__
+        actor_name = actor_name or getattr(fn, "__name__", str(fn))
         queues_names = [queue_name]
         if alternative_queues is not None:
             queues_names += alternative_queues
@@ -234,8 +234,9 @@ class Actor[**P, R]:
         Returns:
           Message: A message that can be enqueued on a broker.
         """
-        for middleware in self.broker.middleware:
-            options = middleware.update_options_before_create_message(options, self.broker, self.actor_name)
+        if self.broker is not None:
+            for middleware in self.broker.middleware:
+                options = middleware.update_options_before_create_message(options, self.broker, self.actor_name)
 
         if queue_name is not None:
             if queue_name not in self.queue_names:

--- a/remoulade/actor.py
+++ b/remoulade/actor.py
@@ -51,7 +51,7 @@ def actor(
     queue_name: str = "default",
     alternative_queues: list[str] | None = None,
     priority: int = 0,
-    **options: Any,
+    **options: object,
 ) -> "Callable[[Callable[P, R]], Actor[P, R]]": ...
 
 
@@ -63,7 +63,7 @@ def actor[**P, R](
     queue_name: str = "default",
     alternative_queues: list[str] | None = None,
     priority: int = 0,
-    **options: Any,
+    **options: object,
 ) -> "Actor[P, R]": ...
 
 
@@ -170,7 +170,7 @@ class Actor[**P, R]:
         queue_name: str,
         alternative_queues: list[str] | None,
         priority: int,
-        options: Any,
+        options: dict[str, Any],
     ) -> None:
         self.logger = get_logger(fn.__module__, actor_name)
         self.fn = fn
@@ -194,7 +194,7 @@ class Actor[**P, R]:
     def queue_names(self):
         return [self.queue_name] + (self.alternative_queues or [])
 
-    def message(self, *args: Any, **kwargs: Any) -> Message[Result[R]]:
+    def message(self, *args: Any, **kwargs: Any) -> Message[Result[R]]:  # ruff: ignore[ANN401]
         """Build a message.  This method is useful if you want to
         compose actors.  See the actor composition documentation for
         details.
@@ -218,7 +218,7 @@ class Actor[**P, R]:
         args: tuple[Any, ...] | None = None,
         kwargs: dict[str, Any] | None = None,
         queue_name: str | None = None,
-        **options: Any,
+        **options: object,
     ) -> Message[Result[R]]:
         """Build a message with an arbitrary set of processing options.
         This method is useful if you want to compose actors.  See the
@@ -271,7 +271,7 @@ class Actor[**P, R]:
         kwargs: dict[str, Any] | None = None,
         queue_name: str | None = None,
         delay: int | None = None,
-        **options: Any,
+        **options: object,
     ) -> Message[Result[R]]:
         """Asynchronously send a message to this actor, along with an
         arbitrary set of processing options for the broker and

--- a/remoulade/api/main.py
+++ b/remoulade/api/main.py
@@ -102,8 +102,7 @@ def requeue_message(message_id):
     if pipe_target is None:
         actor.send_with_options(**payload, **state.options)
         return {"result": "ok"}
-    else:
-        return {"error": "requeue message in a pipeline not supported"}, 400
+    return {"error": "requeue message in a pipeline not supported"}, 400
 
 
 @app.route("/messages/result/<message_id>")

--- a/remoulade/api/main.py
+++ b/remoulade/api/main.py
@@ -96,11 +96,15 @@ def requeue_message(message_id):
     state = backend.get_state(message_id)
     if state is None:
         raise ValidationError(f"No message with id {message_id} exists")
+    if not state.actor_name:
+        raise ValidationError(f"Message {message_id} has no actor_name associated with it")
     actor = broker.get_actor(state.actor_name)
-    payload = {"args": state.args, "kwargs": state.kwargs}
-    pipe_target = state.options.get("pipe_target")
+    options = state.options or {}
+    pipe_target = options.get("pipe_target")
     if pipe_target is None:
-        actor.send_with_options(**payload, **state.options)
+        args = tuple(state.args) if state.args is not None else None
+        kwargs = state.kwargs or {}
+        actor.send_with_options(args=args, kwargs=kwargs, **options)
         return {"result": "ok"}
     return {"error": "requeue message in a pipeline not supported"}, 400
 

--- a/remoulade/api/state.py
+++ b/remoulade/api/state.py
@@ -1,6 +1,14 @@
+from dataclasses import fields
+
 from flask import Blueprint
 from flask_apispec import doc, marshal_with
-from marshmallow import Schema, ValidationError, fields, validate, validates_schema
+from marshmallow import (
+    Schema,
+    ValidationError,
+    fields as mm_fields,
+    validate,
+    validates_schema,
+)
 from werkzeug.exceptions import NotFound
 
 from remoulade import get_broker
@@ -16,22 +24,22 @@ class StatesParamsSchema(Schema):
     Class to validate the state search parameters
     """
 
-    sort_column = fields.Str(
+    sort_column = mm_fields.Str(
         allow_none=True,
-        validate=validate.OneOf([field for field in State._fields if field not in ["args", "kwargs", "options"]]),
+        validate=validate.OneOf([f.name for f in fields(State) if f.name not in {"args", "kwargs", "options"}]),
     )
-    sort_direction = fields.Str(allow_none=True, validate=validate.OneOf(["asc", "desc"]))
-    size = fields.Int(allow_none=True, validate=validate.Range(min=1, max=1000))
-    offset = fields.Int(load_default=0)
-    selected_actors = fields.List(fields.String, allow_none=True)
-    selected_statuses = fields.List(
-        fields.String(validate=validate.OneOf([status.name for status in StateStatusesEnum])),
+    sort_direction = mm_fields.Str(allow_none=True, validate=validate.OneOf(["asc", "desc"]))
+    size = mm_fields.Int(allow_none=True, validate=validate.Range(min=1, max=1000))
+    offset = mm_fields.Int(load_default=0)
+    selected_actors = mm_fields.List(mm_fields.String, allow_none=True)
+    selected_statuses = mm_fields.List(
+        mm_fields.String(validate=validate.OneOf([status.name for status in StateStatusesEnum])),
         allow_none=True,
     )
-    selected_message_ids = fields.List(fields.String, allow_none=True)
-    selected_composition_ids = fields.List(fields.String, allow_none=True)
-    start_datetime = fields.DateTime(allow_none=True)
-    end_datetime = fields.DateTime(allow_none=True)
+    selected_message_ids = mm_fields.List(mm_fields.String, allow_none=True)
+    selected_composition_ids = mm_fields.List(mm_fields.String, allow_none=True)
+    start_datetime = mm_fields.DateTime(allow_none=True)
+    end_datetime = mm_fields.DateTime(allow_none=True)
 
     @validates_schema
     def validate_sort(self, data, **kwargs):
@@ -40,24 +48,24 @@ class StatesParamsSchema(Schema):
 
 
 class StateSchema(Schema):
-    message_id = fields.Str()
-    status = fields.Str(allow_none=True)
-    actor_name = fields.Str(allow_none=True)
-    args = fields.List(fields.Raw(), allow_none=True)
-    kwargs = fields.Dict(keys=fields.Str(), values=fields.Raw(), allow_none=True)
-    options = fields.Dict(keys=fields.Str(), values=fields.Raw(), allow_none=True)
-    progress = fields.Float(allow_none=True)
-    priority = fields.Int(allow_none=True)
-    enqueued_datetime = fields.Str(allow_none=True)
-    started_datetime = fields.Str(allow_none=True)
-    end_datetime = fields.Str(allow_none=True)
-    queue_name = fields.Str(allow_none=True)
-    composition_id = fields.Str(allow_none=True)
+    message_id = mm_fields.Str()
+    status = mm_fields.Str(allow_none=True)
+    actor_name = mm_fields.Str(allow_none=True)
+    args = mm_fields.List(mm_fields.Raw(), allow_none=True)
+    kwargs = mm_fields.Dict(keys=mm_fields.Str(), values=mm_fields.Raw(), allow_none=True)
+    options = mm_fields.Dict(keys=mm_fields.Str(), values=mm_fields.Raw(), allow_none=True)
+    progress = mm_fields.Float(allow_none=True)
+    priority = mm_fields.Int(allow_none=True)
+    enqueued_datetime = mm_fields.Str(allow_none=True)
+    started_datetime = mm_fields.Str(allow_none=True)
+    end_datetime = mm_fields.Str(allow_none=True)
+    queue_name = mm_fields.Str(allow_none=True)
+    composition_id = mm_fields.Str(allow_none=True)
 
 
 class StatesResponseSchema(Schema):
-    data = fields.List(fields.Nested(StateSchema))
-    count = fields.Int()
+    data = mm_fields.List(mm_fields.Nested(StateSchema))
+    count = mm_fields.Int()
 
 
 @messages_bp.route("/states", methods=["POST"])

--- a/remoulade/broker.py
+++ b/remoulade/broker.py
@@ -94,7 +94,9 @@ def _get_middleware_order():
     except ImportError:
         # Fall back to the legacy external instrumentor if available
         try:
-            from opentelemetry.instrumentation.remoulade import _InstrumentationMiddleware
+            from opentelemetry.instrumentation.remoulade import (  # ty: ignore[unresolved-import]
+                _InstrumentationMiddleware,
+            )
 
             middleware_order.insert(0, _InstrumentationMiddleware)
         except ImportError:

--- a/remoulade/broker.py
+++ b/remoulade/broker.py
@@ -14,10 +14,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from collections.abc import Iterable
 from contextlib import contextmanager, suppress
-from queue import Queue
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from .cancel import Cancel, CancelBackend
 from .concurrent import ConcurrencyBackend, Concurrent
@@ -51,6 +49,9 @@ from .results import ResultBackend, Results
 from .state import MessageState, StateBackend
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from queue import Queue
+
     from .actor import Actor
     from .message import Message
     from .middleware import Middleware
@@ -319,11 +320,13 @@ class Broker:
         }
         try:
             middleware_class, exception = backends[name]
-            middleware: Results | Cancel | MessageState | None = self.get_middleware(middleware_class)
+            middleware = cast(
+                "Results | Cancel | MessageState | None",
+                self.get_middleware(middleware_class),
+            )
             if middleware is not None:
                 return middleware.backend
-            else:
-                raise exception
+            raise exception
         except KeyError as e:
             raise ValueError("invalid backend name") from e
 
@@ -425,8 +428,7 @@ class Broker:
         """If your broker doesn't support native delay, you need to override this method"""
         if self.supports_native_delay:
             return message
-        else:
-            raise NotImplementedError("delay is not supported natively, you need to implement it")
+        raise NotImplementedError("delay is not supported natively, you need to implement it")
 
     def _enqueue(self, message: "Message", *, delay: int | None = None) -> "Message":
         raise NotImplementedError
@@ -550,16 +552,16 @@ class Broker:
         Parameters:
           queue_name(str): The name of the queue to flush.
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def flush_all(self) -> None:  # pragma: no cover
         """Drop all messages from all declared queues."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def join(self, queue_name: str, *, timeout: int | None = None) -> None:  # pragma: no cover
         """Wait for all the messages on the given queue to be processed.
         This method is only meant to be used in tests to wait for all the messages in a queue to be processed."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
 
 class Consumer:

--- a/remoulade/brokers/local.py
+++ b/remoulade/brokers/local.py
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING, Any, override
 
 from ..broker import Broker, Consumer, MessageProxy
 from ..common import current_millis
-from ..message import Message
 from ..middleware import SkipMessage
 from ..results import Results
 from ..results.backends import LocalBackend
@@ -27,6 +26,7 @@ from ..results.backends import LocalBackend
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from ..message import Message
     from ..middleware import Middleware
 
 
@@ -96,8 +96,7 @@ class LocalBroker(Broker):
         self.emit_before("enqueue", message, delay)
         self.emit_after("enqueue", message, delay)
 
-        message = self._enqueue(message, delay=delay)
-        return message
+        return self._enqueue(message, delay=delay)
 
     @override
     def _enqueue(self, message: "Message", *, delay: int | None = None):
@@ -138,7 +137,7 @@ class LocalBroker(Broker):
         return [self._enqueue(message, delay=delay) for message in messages]
 
     @override
-    def flush(self, _: str) -> None:
+    def flush(self, queue_name: str) -> None:
         pass
 
     @override

--- a/remoulade/brokers/postgres.py
+++ b/remoulade/brokers/postgres.py
@@ -22,7 +22,7 @@ from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from threading import Event, Lock, Thread, local
-from typing import TYPE_CHECKING, Any, Final, override
+from typing import TYPE_CHECKING, Any, Final, cast, override
 from urllib.parse import urlparse
 
 import psycopg
@@ -156,7 +156,11 @@ class PostgresBroker(Broker):
         The active SQLAlchemy connection is stored on thread-local state so
         queue operations can reuse it while the context is open.
         """
-        with self.client.engine.begin() as connection:
+        engine = self.client.engine
+        if engine is None:
+            raise RuntimeError("Engine is not initialized on PGMQ client.")
+
+        with engine.begin() as connection:
             self.state.transaction_connection = connection
             try:
                 yield
@@ -517,7 +521,7 @@ class _PostgresListener:
         except Exception as e:
             self._logger.warning(
                 "Failed to open shared LISTEN/NOTIFY connection; consumers will fall back to polling. Error: %s",
-                str(e),
+                e,
                 exc_info=True,
             )
             if connection is not None:
@@ -542,7 +546,7 @@ class _PostgresListener:
             try:
                 self._connection.close()
             except Exception as e:
-                self._logger.error("Failed to close shared listener connection: %s", str(e))
+                self._logger.error("Failed to close shared listener connection: %s", e)
             self._connection = None
 
     def _drain_pending_listen(self) -> None:
@@ -589,15 +593,16 @@ class _PostgresListener:
                 backoff = LISTENER_RECONNECT_BACKOFF_MIN_S
             try:
                 self._drain_pending_listen()
-                for notify in self._connection.notifies(timeout=0.5, stop_after=1):
-                    self._wake_channel(notify.channel)
+                if self._connection is not None:
+                    for notify in self._connection.notifies(timeout=0.5, stop_after=1):
+                        self._wake_channel(notify.channel)
             except Exception as e:
                 if self._stop.is_set():
                     break
                 self._logger.warning(
                     "Shared LISTEN/NOTIFY listener error; consumers will fall back to polling while it "
                     "reconnects. Error: %s",
-                    str(e),
+                    e,
                     exc_info=True,
                 )
                 self._drop_connection()
@@ -666,7 +671,9 @@ class _PostgresConsumer(Consumer):
         """Normalize a PGMQ read result into a list."""
         if messages is None:
             return []
-        return [messages] if not isinstance(messages, list) else messages
+        if isinstance(messages, list):
+            return cast("list[PostgresQueueMessage]", messages)
+        return [messages]
 
     def _read_immediate(self, qty: int) -> list[PostgresQueueMessage]:
         """Read up to ``qty`` messages without polling."""
@@ -743,7 +750,7 @@ class _PostgresConsumer(Consumer):
                 self.broker.logger.warning(
                     "Failed to extend visibility timeout heartbeat for queue %s. Error: %s",
                     self.queue_name,
-                    str(e),
+                    e,
                     exc_info=True,
                 )
 
@@ -780,11 +787,10 @@ class _PostgresConsumer(Consumer):
         try:
             self.client.archive(self.queue_name, message._postgres_message.msg_id)
         except Exception:
-            self.broker.logger.error(
+            self.broker.logger.exception(
                 "Failed to archive message %s on queue %s; it will be redelivered after its visibility timeout.",
                 message._postgres_message.msg_id,
                 self.queue_name,
-                exc_info=True,
             )
 
     @override

--- a/remoulade/brokers/postgres.py
+++ b/remoulade/brokers/postgres.py
@@ -22,7 +22,7 @@ from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from threading import Event, Lock, Thread, local
-from typing import TYPE_CHECKING, Any, Final, override
+from typing import TYPE_CHECKING, Any, Final, cast, override
 from urllib.parse import urlparse
 
 import psycopg
@@ -156,7 +156,11 @@ class PostgresBroker(Broker):
         The active SQLAlchemy connection is stored on thread-local state so
         queue operations can reuse it while the context is open.
         """
-        with self.client.engine.begin() as connection:
+        engine = self.client.engine
+        if engine is None:
+            raise RuntimeError("Engine is not initialized on PGMQ client.")
+
+        with engine.begin() as connection:
             self.state.transaction_connection = connection
             try:
                 yield
@@ -500,7 +504,7 @@ class _PostgresListener:
         except Exception as e:
             self._logger.warning(
                 "Failed to open shared LISTEN/NOTIFY connection; consumers will fall back to polling. Error: %s",
-                str(e),
+                e,
                 exc_info=True,
             )
             if connection is not None:
@@ -525,7 +529,7 @@ class _PostgresListener:
             try:
                 self._connection.close()
             except Exception as e:
-                self._logger.error("Failed to close shared listener connection: %s", str(e))
+                self._logger.error("Failed to close shared listener connection: %s", e)
             self._connection = None
 
     def _drain_pending_listen(self) -> None:
@@ -572,15 +576,16 @@ class _PostgresListener:
                 backoff = LISTENER_RECONNECT_BACKOFF_MIN_S
             try:
                 self._drain_pending_listen()
-                for notify in self._connection.notifies(timeout=0.5, stop_after=1):
-                    self._wake_channel(notify.channel)
+                if self._connection is not None:
+                    for notify in self._connection.notifies(timeout=0.5, stop_after=1):
+                        self._wake_channel(notify.channel)
             except Exception as e:
                 if self._stop.is_set():
                     break
                 self._logger.warning(
                     "Shared LISTEN/NOTIFY listener error; consumers will fall back to polling while it "
                     "reconnects. Error: %s",
-                    str(e),
+                    e,
                     exc_info=True,
                 )
                 self._drop_connection()
@@ -649,7 +654,9 @@ class _PostgresConsumer(Consumer):
         """Normalize a PGMQ read result into a list."""
         if messages is None:
             return []
-        return [messages] if not isinstance(messages, list) else messages
+        if isinstance(messages, list):
+            return cast("list[PostgresQueueMessage]", messages)
+        return [messages]
 
     def _read_immediate(self, qty: int) -> list[PostgresQueueMessage]:
         """Read up to ``qty`` messages without polling."""
@@ -726,7 +733,7 @@ class _PostgresConsumer(Consumer):
                 self.broker.logger.warning(
                     "Failed to extend visibility timeout heartbeat for queue %s. Error: %s",
                     self.queue_name,
-                    str(e),
+                    e,
                     exc_info=True,
                 )
 
@@ -763,11 +770,10 @@ class _PostgresConsumer(Consumer):
         try:
             self.client.archive(self.queue_name, message.delivery_id)
         except Exception:
-            self.broker.logger.error(
+            self.broker.logger.exception(
                 "Failed to archive message %s on queue %s; it will be redelivered after its visibility timeout.",
                 message.delivery_id,
                 self.queue_name,
-                exc_info=True,
             )
 
     @override

--- a/remoulade/brokers/rabbitmq.py
+++ b/remoulade/brokers/rabbitmq.py
@@ -189,7 +189,7 @@ class RabbitmqBroker(Broker):
         try:
             del self.connection
         except Exception:  # pragma: no cover
-            self.logger.error("Encountered an error while connection.", exc_info=True)
+            self.logger.exception("Encountered an error while connection.")
         self._connection = None
         self.clear_channel_pools()
         self.logger.debug("Channels and connections closed.")
@@ -214,7 +214,7 @@ class RabbitmqBroker(Broker):
 
             self.clear_channel_pools()
 
-            raise ConnectionClosed(e) from None
+            raise ConnectionClosed(str(e)) from None
         return _RabbitmqConsumer(self.connection, queue_name, prefetch, timeout)
 
     def _declare_rabbitmq_queues(self):
@@ -373,7 +373,7 @@ class RabbitmqBroker(Broker):
 
                 attempts += 1
                 if self._has_transaction or attempts > MAX_ENQUEUE_ATTEMPTS:
-                    raise ConnectionClosed(e) from None
+                    raise ConnectionClosed(str(e)) from None
 
                 self.logger.info("Retrying enqueue due to closed connection. [%d/%d]", attempts, MAX_ENQUEUE_ATTEMPTS)
 
@@ -469,25 +469,25 @@ class _RabbitmqConsumer(Consumer):
             self.channel.basic.consume(queue=queue_name, no_ack=False)
             self.timeout = timeout
         except (AMQPConnectionError, AMQPChannelError) as e:
-            raise ConnectionClosed(e) from None
+            raise ConnectionClosed(str(e)) from None
 
     @override
     def ack(self, message):
         try:
             message.ack()
         except (AMQPConnectionError, AMQPChannelError) as e:
-            raise ConnectionClosed(e) from None
+            raise ConnectionClosed(str(e)) from None
         except Exception:  # pragma: no cover
-            self.logger.error("Failed to ack message.", exc_info=True)
+            self.logger.exception("Failed to ack message.")
 
     @override
     def nack(self, message):
         try:
             message.nack(requeue=False)
         except (AMQPConnectionError, AMQPChannelError) as e:
-            raise ConnectionClosed(e) from None
+            raise ConnectionClosed(str(e)) from None
         except Exception:  # pragma: no cover
-            self.logger.error("Failed to nack message.", exc_info=True)
+            self.logger.exception("Failed to nack message.")
 
     @override
     def requeue(self, messages):
@@ -509,7 +509,7 @@ class _RabbitmqConsumer(Consumer):
 
             return _RabbitmqMessage(message) if message else None
         except (AMQPConnectionError, AMQPChannelError) as e:
-            raise ConnectionClosed(e) from None
+            raise ConnectionClosed(str(e)) from None
 
     @override
     def close(self):

--- a/remoulade/brokers/stub.py
+++ b/remoulade/brokers/stub.py
@@ -99,7 +99,9 @@ class StubBroker(Broker):
         if queue_name not in self.queues:
             raise QueueNotFound(queue_name)
 
-        self.queues[queue_name].put(message.encode_in_bytes())
+        queue = self.queues[queue_name]
+        if queue is not None:
+            queue.put(message.encode_in_bytes())
         return message
 
     def _enqueue_many(self, messages, *, delay=None):
@@ -111,8 +113,10 @@ class StubBroker(Broker):
         Parameters:
           queue_name(str): The queue to flush.
         """
-        for _ in iter_queue(self.queues[queue_name]):
-            self.queues[queue_name].task_done()
+        queue = self.queues[queue_name]
+        if queue is not None:
+            for _ in iter_queue(queue):
+                queue.task_done()
 
     def flush_all(self):
         """Drop all messages from all declared queues."""
@@ -144,7 +148,8 @@ class StubBroker(Broker):
                 # again in case the messages that were on the DQ got
                 # moved back on $queue.
                 for name in [queue_name, dq_name(queue_name)]:
-                    if self.queues[name].unfinished_tasks:
+                    queue = self.queues[name]
+                    if queue is not None and queue.unfinished_tasks:
                         break
                 else:
                     return

--- a/remoulade/cancel/backends/stub.py
+++ b/remoulade/cancel/backends/stub.py
@@ -32,7 +32,7 @@ class StubBackend(CancelBackend):
         super().__init__(cancellation_ttl=cancellation_ttl)
         self.cancellations: dict[str, float] = {}
 
-    def is_canceled(self, message_id: str, composition_id: str) -> bool:
+    def is_canceled(self, message_id: str, composition_id: str | None) -> bool:
         return any(
             self.cancellations.get(key, -float("inf")) > time.time() - self.cancellation_ttl
             for key in [message_id, composition_id]

--- a/remoulade/cancel/middleware.py
+++ b/remoulade/cancel/middleware.py
@@ -66,6 +66,9 @@ class Cancel(Middleware):
         self.backend = backend
 
     def before_process_message(self, broker, message):
+        if self.backend is None:
+            return
+
         composition_id = message.options.get("composition_id")
 
         if self.backend.is_canceled(message.message_id, composition_id):
@@ -74,7 +77,7 @@ class Cancel(Middleware):
     def after_process_message(self, broker, message, *, result=None, exception=None):
         """Cancel all the messages in the composition if one of the message of the composition fails"""
 
-        if exception is None:
+        if exception is None or self.backend is None:
             return
 
         cancel_on_error = message.options.get("cancel_on_error")

--- a/remoulade/collection_results.py
+++ b/remoulade/collection_results.py
@@ -18,14 +18,17 @@ from __future__ import annotations
 
 import time
 from collections import deque
-from collections.abc import Generator, Iterable
-from typing import Any, Literal, TypeVar, Union, cast, overload
-
-from remoulade.results.errors import ErrorStored
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, Union, cast, overload
 
 from .broker import get_broker
 from .result import Result
-from .results import ResultBackend
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
+
+    from remoulade.results.errors import ErrorStored
+
+    from .results import ResultBackend
 
 ResultT = TypeVar("ResultT", bound=Union[Result, "CollectionResults"])
 R = TypeVar("R")
@@ -78,7 +81,7 @@ class CollectionResults[ResultT: Result | "CollectionResults"]:
             if isinstance(child, CollectionResults):
                 message_ids += child.message_ids
             else:
-                message_ids += [cast(Result[Any], child).message_id]
+                message_ids += [cast("Result[Any]", child).message_id]
         return message_ids
 
     @property
@@ -170,7 +173,7 @@ class CollectionResults[ResultT: Result | "CollectionResults"]:
 
                 yield list(child.get(block=block, timeout=timeout, raise_on_error=raise_on_error, forget=forget))
             else:
-                message_ids.append(cast(Result[Any], child).message_id)
+                message_ids.append(cast("Result[Any]", child).message_id)
 
         if message_ids:
             yield from self._backend.get_results(

--- a/remoulade/composition.py
+++ b/remoulade/composition.py
@@ -73,8 +73,6 @@ class pipeline[ResultsT: "Result[Any] | CollectionResults[Any]"]:
     @overload
     def __init__(
         self,
-        # we should actually not use ResultTs here but define a new type var that is only bound to Result
-        # but then mypy gets lost, so reusing ResultsT and ignoring the error
         children: tuple[*tuple[Message[Any] | pipeline[Any] | group[Any], ...], Message[Any] | pipeline[ResultsT]],
         cancel_on_error: bool = False,
     ): ...
@@ -225,9 +223,7 @@ class group[ResultsT: "Result[Any] | CollectionResults[Any]"]:
 
     def __init__(
         self,
-        # we should actually not use ResultTs here but define a new type var that is only bound to Result
-        # but then mypy gets lost, so reusing ResultsT and ignoring the error
-        children: Iterable[pipeline[ResultsT] | Message[ResultsT]],  # type: ignore
+        children: Iterable[pipeline[ResultsT] | Message[Any]],
         group_id: str | None = None,
         cancel_on_error: bool = False,
     ) -> None:

--- a/remoulade/composition.py
+++ b/remoulade/composition.py
@@ -16,16 +16,16 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import annotations
 
-from collections import namedtuple
-from collections.abc import Iterable
 from contextlib import nullcontext
-from typing import TYPE_CHECKING, Any, Self, TypedDict, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, NamedTuple, Self, TypedDict, TypeVar, cast, overload
 
 from .broker import get_broker
 from .collection_results import CollectionResults
 from .common import flatten, generate_unique_id
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from .message import Message
     from .result import Result
 
@@ -38,7 +38,7 @@ class GroupInfoDict(TypedDict):
     children_count: int
 
 
-class GroupInfo(namedtuple("GroupInfo", ("group_id", "children_count"))):
+class GroupInfo(NamedTuple):
     """Encapsulates metadata about a group being sent to multiple actors.
 
     Parameters:
@@ -46,11 +46,11 @@ class GroupInfo(namedtuple("GroupInfo", ("group_id", "children_count"))):
       children_count(int)
     """
 
-    def __new__(cls, *, group_id: str, children_count: int):
-        return super().__new__(cls, group_id, children_count)
+    group_id: str
+    children_count: int
 
     def asdict(self) -> GroupInfoDict:
-        return cast(GroupInfoDict, self._asdict())
+        return cast("GroupInfoDict", self._asdict())
 
 
 class pipeline[ResultsT: "Result[Any] | CollectionResults[Any]"]:
@@ -75,9 +75,7 @@ class pipeline[ResultsT: "Result[Any] | CollectionResults[Any]"]:
         self,
         # we should actually not use ResultTs here but define a new type var that is only bound to Result
         # but then mypy gets lost, so reusing ResultsT and ignoring the error
-        children: tuple[  # type: ignore
-            *tuple[Message[Any] | pipeline[Any] | group[Any], ...], Message[ResultsT] | pipeline[ResultsT]
-        ],
+        children: tuple[*tuple[Message[Any] | pipeline[Any] | group[Any], ...], Message[Any] | pipeline[ResultsT]],
         cancel_on_error: bool = False,
     ): ...
 
@@ -203,7 +201,7 @@ class pipeline[ResultsT: "Result[Any] | CollectionResults[Any]"]:
     def result(self) -> ResultsT:
         """Result of the last message/group of the pipeline"""
         last_child = self.children[-1]
-        return cast(ResultsT, last_child.results if isinstance(last_child, group) else last_child.result)
+        return cast("ResultsT", last_child.results if isinstance(last_child, group) else last_child.result)
 
     def cancel(self) -> None:
         """Mark all the children as cancelled"""
@@ -275,11 +273,15 @@ class group[ResultsT: "Result[Any] | CollectionResults[Any]"]:
         messages: list[Message] = []
         for group_child in self.children:
             if isinstance(group_child, pipeline):
-                messages += group_child.build(
+                pipe_child = cast("pipeline", group_child)
+                messages += pipe_child.build(
                     last_options=options, composition_id=composition_id, cancel_on_error=cancel_on_error
                 )
+            elif isinstance(group_child, group):
+                group_subchild = cast("group", group_child)
+                messages += group_subchild.build(options=options)
             else:
-                messages += [group_child.build(options)]
+                messages.append(group_child.build(options=options))
         return messages
 
     @property
@@ -312,7 +314,9 @@ class group[ResultsT: "Result[Any] | CollectionResults[Any]"]:
     @property
     def results(self) -> CollectionResults[ResultsT]:
         """CollectionResults created from this group, used for result related methods"""
-        return cast(CollectionResults[ResultsT], CollectionResults(children=[child.result for child in self.children]))
+        return cast(
+            "CollectionResults[ResultsT]", CollectionResults(children=[child.result for child in self.children])
+        )
 
     def cancel(self) -> None:
         """Mark all the children as cancelled"""

--- a/remoulade/encoder.py
+++ b/remoulade/encoder.py
@@ -104,7 +104,7 @@ class PickleEncoder(Encoder):
 
     @override
     def decode_bytes(self, data: bytes) -> MessageData:
-        return pickle.loads(data)  # noqa: S301
+        return pickle.loads(data)  # ruff: ignore[S301]
 
     @override
     def _encode_in_json(self, data: MessageData) -> JsonData:

--- a/remoulade/errors.py
+++ b/remoulade/errors.py
@@ -48,7 +48,7 @@ class UnknownStrategy(RemouladeError):
     """Raised when the backoff_strategy option is set to an unexpected value."""
 
 
-class ConnectionError(BrokerError):  # noqa: A001
+class ConnectionError(BrokerError):  # ruff: ignore[A001]
     """Base class for broker connection-related errors."""
 
 

--- a/remoulade/generic.py
+++ b/remoulade/generic.py
@@ -29,13 +29,13 @@ class generic_actor(type):
             options.pop("abstract", False)
 
             clazz_instance = clazz()
-            actor_instance = actor(clazz_instance, **options)  # type: ignore
-            clazz.__getattr__ = generic_actor.__getattr__  # type: ignore
+            actor_instance = actor(clazz_instance, **options)
+            clazz.__getattr__ = generic_actor.__getattr__
             clazz_instance.__actor__ = actor_instance
             return clazz_instance
 
-        meta.abstract = False  # type: ignore
-        clazz.__actor__ = None  # type: ignore
+        meta.abstract = False  # ty: ignore[unresolved-attribute]
+        clazz.__actor__ = None  # ty: ignore[unresolved-attribute]
         return clazz
 
     def __getattr__(cls, name):

--- a/remoulade/helpers/backoff.py
+++ b/remoulade/helpers/backoff.py
@@ -80,8 +80,7 @@ def compute_backoff_exponential(attempts: int, *, min_backoff: int, max_backoff:
       int: The backoff in milliseconds.
     """
     exponent = min(attempts, max_retries - 1)
-    backoff = min(min_backoff * 2**exponent, max_backoff)
-    return backoff
+    return min(min_backoff * 2**exponent, max_backoff)
 
 
 def compute_backoff_spread_exponential(attempts: int, *, min_backoff: int, max_backoff: int, max_retries: int):
@@ -100,5 +99,4 @@ def compute_backoff_spread_exponential(attempts: int, *, min_backoff: int, max_b
     if max_retries == 1:
         return min_backoff
     exponent = min(attempts / (max_retries - 1), 1)
-    backoff = min_backoff * ((max_backoff / min_backoff) ** exponent)
-    return backoff
+    return min_backoff * ((max_backoff / min_backoff) ** exponent)

--- a/remoulade/helpers/postgres_client.py
+++ b/remoulade/helpers/postgres_client.py
@@ -26,7 +26,10 @@ from contextlib import contextmanager
 from typing import Any
 
 from pgmq import SQLAlchemyPGMQueue
-from sqlalchemy import Connection, text
+from sqlalchemy import Connection, Executable, text
+
+if SQLAlchemyPGMQueue is None:
+    raise ImportError("SQLAlchemyPGMQueue is not available. Please check your 'pgmq' installation.")
 
 from ..actor import QUEUE_NAME_PATTERN
 
@@ -91,7 +94,7 @@ class RemouladePostgresClient(SQLAlchemyPGMQueue):
             UPDATE pgmq."q_{queue}"
             SET headers = coalesce(headers, '{{}}'::jsonb) || CAST(:patch AS jsonb)
             WHERE msg_id = :msg_id
-        """)  # noqa: S608
+        """)  # ruff: ignore[S608]
         return self._run(statement, {"msg_id": msg_id, "patch": json.dumps(patch)}, conn) > 0
 
     @contextmanager
@@ -100,10 +103,12 @@ class RemouladePostgresClient(SQLAlchemyPGMQueue):
         if conn is not None:
             yield conn
             return
+        if self.engine is None:
+            raise RuntimeError("PostgresClient engine is not initialized")
         with self.engine.begin() as connection:
             yield connection
 
-    def _run(self, statement: Any, params: dict[str, Any], conn: Connection | None) -> int:
+    def _run(self, statement: Executable, params: dict[str, Any], conn: Connection | None) -> int:
         """Execute a write statement, returning the number of affected rows."""
         with self._connection(conn) as connection:
             return connection.execute(statement, params).rowcount

--- a/remoulade/helpers/queues.py
+++ b/remoulade/helpers/queues.py
@@ -69,9 +69,7 @@ def join_all(joinables, timeout):
 
 def q_name(queue_name):
     """Returns the canonical queue name for a given queue."""
-    if queue_name.endswith(".DQ") or queue_name.endswith(".XQ"):
-        return queue_name[:-3]
-    return queue_name
+    return queue_name.removesuffix(".DQ").removesuffix(".XQ")
 
 
 def dq_name(queue_name):
@@ -82,8 +80,7 @@ def dq_name(queue_name):
     if queue_name.endswith(".DQ"):
         return queue_name
 
-    if queue_name.endswith(".XQ"):
-        queue_name = queue_name[:-3]
+    queue_name = queue_name.removesuffix(".XQ")
     return queue_name + ".DQ"
 
 
@@ -95,6 +92,5 @@ def xq_name(queue_name):
     if queue_name.endswith(".XQ"):
         return queue_name
 
-    if queue_name.endswith(".DQ"):
-        queue_name = queue_name[:-3]
+    queue_name = queue_name.removesuffix(".DQ")
     return queue_name + ".XQ"

--- a/remoulade/helpers/redis_client.py
+++ b/remoulade/helpers/redis_client.py
@@ -32,16 +32,18 @@ def redis_client(url: str | None, socket_timeout: float | None = None, **paramet
     if url:
         url_parsed = urlparse(url)
         if url_parsed.scheme == "sentinel":
+            host = url_parsed.hostname or "localhost"
+            port = url_parsed.port or 26379
             sentinel_kwargs = {"password": url_parsed.password, **connection_parameters}
-            sentinel = redis.Sentinel([(url_parsed.hostname, url_parsed.port)], sentinel_kwargs=sentinel_kwargs)
+            sentinel = redis.Sentinel([(host, port)], sentinel_kwargs=sentinel_kwargs)
             return sentinel.master_for(
                 service_name=os.path.normpath(url_parsed.path).split("/")[1],
                 password=url_parsed.password,
                 **connection_parameters,
             )
-        else:
-            parameters["connection_pool"] = redis.ConnectionPool.from_url(url, **connection_parameters)
-            return redis.Redis(**parameters)
+        parameters["connection_pool"] = redis.ConnectionPool.from_url(url, **connection_parameters)
+        return redis.Redis(**parameters)
+    return None
 
 
 def async_redis_client(url: str | None, socket_timeout: float | None = None, **parameters):
@@ -51,13 +53,15 @@ def async_redis_client(url: str | None, socket_timeout: float | None = None, **p
     if url:
         url_parsed = urlparse(url)
         if url_parsed.scheme == "sentinel":
+            host = url_parsed.hostname or "localhost"
+            port = url_parsed.port or 26379
             sentinel_kwargs = {"password": url_parsed.password, **connection_parameters}
-            sentinel = redis_async.Sentinel([(url_parsed.hostname, url_parsed.port)], sentinel_kwargs=sentinel_kwargs)
+            sentinel = redis_async.Sentinel([(host, port)], sentinel_kwargs=sentinel_kwargs)
             return sentinel.master_for(
                 service_name=os.path.normpath(url_parsed.path).split("/")[1],
                 password=url_parsed.password,
                 **connection_parameters,
             )
-        else:
-            parameters["connection_pool"] = redis_async.ConnectionPool.from_url(url, **connection_parameters)
-            return redis_async.Redis(**parameters)
+        parameters["connection_pool"] = redis_async.ConnectionPool.from_url(url, **connection_parameters)
+        return redis_async.Redis(**parameters)
+    return None

--- a/remoulade/message.py
+++ b/remoulade/message.py
@@ -139,7 +139,7 @@ class Message[ResultT: Result[Any]]:
 
     @property
     def result(self) -> ResultT:
-        return cast(ResultT, Result(message_id=self.message_id))
+        return cast("ResultT", Result(message_id=self.message_id))
 
     def __str__(self) -> str:
         return f"{self.actor_name} / {self.message_id}"

--- a/remoulade/message.py
+++ b/remoulade/message.py
@@ -30,7 +30,7 @@ from .errors import InvalidProgress
 from .result import Result
 
 #: The global encoder instance.
-global_encoder = JSONEncoder()  # type: Encoder
+global_encoder: Encoder = JSONEncoder()
 
 
 def get_encoder() -> Encoder:

--- a/remoulade/middleware/__init__.py
+++ b/remoulade/middleware/__init__.py
@@ -35,11 +35,11 @@ from .worker_thread_logging import WorkerThreadLogging
 CURRENT_OS = platform.system()
 
 if CURRENT_OS != "Windows":
-    from .prometheus import Prometheus  # noqa: F401
+    from .prometheus import Prometheus  # ruff: ignore[F401]
 
 _has_tracing = False
 try:
-    from .tracing import OpenTelemetryMiddleware  # noqa: F401
+    from .tracing import OpenTelemetryMiddleware  # ruff: ignore[F401]
 
     _has_tracing = True
 except ImportError:
@@ -73,10 +73,10 @@ __all__ = [
 ]
 
 if CURRENT_OS != "Windows":
-    __all__.append("Prometheus")
+    __all__ += "Prometheus"
 
 if _has_tracing:
-    __all__.append("OpenTelemetryMiddleware")
+    __all__ += "OpenTelemetryMiddleware"
 
 #: The list of middleware that are enabled by default.
 default_middleware = [

--- a/remoulade/middleware/catch_error.py
+++ b/remoulade/middleware/catch_error.py
@@ -19,14 +19,15 @@ class CatchError(Middleware):
 
         if message.failed:
             on_failure = self.get_option("on_failure", broker=broker, message=message)
+            exception_args = getattr(exception, "args", ())
 
             if isinstance(on_failure, str):
                 actor = broker.get_actor(on_failure)
-                actor.send(message.actor_name, type(exception).__name__, exception.args, message.args, message.kwargs)
+                actor.send(message.actor_name, type(exception).__name__, exception_args, message.args, message.kwargs)
             elif isinstance(on_failure, dict):
                 on_failure_message = Message[Any](**on_failure)
                 on_failure_message = on_failure_message.copy(
-                    args=[message.actor_name, type(exception).__name__, exception.args, message.args, message.kwargs]
+                    args=[message.actor_name, type(exception).__name__, exception_args, message.args, message.kwargs]
                 )
                 broker.enqueue(on_failure_message)
 

--- a/remoulade/middleware/heartbeat.py
+++ b/remoulade/middleware/heartbeat.py
@@ -19,7 +19,6 @@ import time
 from functools import partial
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Any
 from urllib.parse import parse_qs, urlsplit
 
 from ..logging import get_logger
@@ -37,7 +36,7 @@ class HeartbeatRequestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         self.server.answer(self)
 
-    def log_message(self, format: str, *args: Any) -> None:  # ruff: ignore[A002]
+    def log_message(self, format: str, *args: object) -> None:  # ruff: ignore[A002]
         return
 
 

--- a/remoulade/middleware/heartbeat.py
+++ b/remoulade/middleware/heartbeat.py
@@ -19,12 +19,13 @@ import time
 from functools import partial
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
 from urllib.parse import parse_qs, urlsplit
 
 from ..logging import get_logger
 from .middleware import Middleware
 
-DEFAULT_HTTP_HOST = "0.0.0.0"  # noqa: S104
+DEFAULT_HTTP_HOST = "0.0.0.0"  # ruff: ignore[S104]
 DEFAULT_HTTP_PORT = 9192
 DEFAULT_THRESHOLD = 2 * 60 * 60
 HEARTBEAT_INTERVAL = 10
@@ -36,7 +37,7 @@ class HeartbeatRequestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         self.server.answer(self)
 
-    def log_message(self, *_args):
+    def log_message(self, format: str, *args: Any) -> None:  # ruff: ignore[A002]
         return
 
 

--- a/remoulade/middleware/logging_metadata.py
+++ b/remoulade/middleware/logging_metadata.py
@@ -63,6 +63,9 @@ class LoggingMetadata(Middleware):
 
         for name in ["message_id", "input"]:
             if name in total_logging_metadata:
-                self.logger.error(f"'{name}' cannot be used as a logging_metadata key. It will be overwritten.")
+                self.logger.error(
+                    "'%s' cannot be used as a logging_metadata key. It will be overwritten.",
+                    name,
+                )
 
         return options

--- a/remoulade/middleware/max_memory.py
+++ b/remoulade/middleware/max_memory.py
@@ -40,7 +40,9 @@ class MaxMemory(Middleware):
             self.logger.error("Worker unable to determine memory usage")
         if used_memory > self.max_memory:
             self.logger.warning(
-                f"Stopping worker thread as used_memory ({used_memory:.2E}Kb) > max_memory ({self.max_memory:.2E}Kb)"
+                "Stopping worker thread as used_memory (%.2EKb) > max_memory (%.2EKb)",
+                used_memory,
+                self.max_memory,
             )
             # stopping the worker thread will in time stop the worker process which check if all workers are still
             # running (via Worker.worker_stopped)

--- a/remoulade/middleware/max_tasks.py
+++ b/remoulade/middleware/max_tasks.py
@@ -24,6 +24,8 @@ class MaxTasks(Middleware):
             self.tasks_count += 1
             if self.tasks_count == self.max_tasks:
                 self.logger.info(
-                    f"Stopping worker thread as completed tasks ({self.tasks_count}) > max_tasks ({self.max_tasks})"
+                    "Stopping worker thread as completed tasks (%s) >= max_tasks (%s)",
+                    self.tasks_count,
+                    self.max_tasks,
                 )
                 thread.stop()

--- a/remoulade/middleware/prometheus.py
+++ b/remoulade/middleware/prometheus.py
@@ -26,10 +26,10 @@ from ..logging import get_logger
 from .middleware import Middleware
 
 #: The default HTTP host the exposition server should bind to.
-DEFAULT_HTTP_HOST = os.getenv("remoulade_prom_host", "127.0.0.1")  # noqa: SIM112
+DEFAULT_HTTP_HOST = os.getenv("remoulade_prom_host", "127.0.0.1")  # ruff: ignore[SIM112]
 
 #: The default HTTP port the exposition server should listen on.
-DEFAULT_HTTP_PORT = int(os.getenv("remoulade_prom_port", "9191"))  # noqa: SIM112
+DEFAULT_HTTP_PORT = int(os.getenv("remoulade_prom_port", "9191"))  # ruff: ignore[SIM112]
 
 #: The default HTTP port the exposition server should listen on.
 DEFAULT_LABEL = "default"
@@ -152,10 +152,12 @@ class Prometheus(Middleware):
         prom.start_http_server(addr=self.http_host, port=self.http_port, registry=self.registry)
 
     def after_worker_boot(self, broker, worker):
-        self.worker_busy.set(0)
+        if self.worker_busy is not None:
+            self.worker_busy.set(0)
 
     def after_worker_shutdown(self, broker, worker):
-        self.worker_busy.set(0)
+        if self.worker_busy is not None:
+            self.worker_busy.set(0)
         self.logger.debug("Shutting down exposition server...")
         # Do not stop it actually
 
@@ -163,11 +165,12 @@ class Prometheus(Middleware):
         self._init_labels(actor)
 
     def after_nack(self, broker, message):
-        labels = self._get_labels(broker, message)
-        self.total_rejected_messages.labels(*labels).inc()
+        if self.total_rejected_messages is not None:
+            labels = self._get_labels(broker, message)
+            self.total_rejected_messages.labels(*labels).inc()
 
     def after_enqueue(self, broker, message, delay, exception=None):
-        if "retries" in message.options:
+        if "retries" in message.options and self.total_retried_messages is not None:
             labels = self._get_labels(broker, message)
             self.total_retried_messages.labels(*labels).inc()
 
@@ -179,10 +182,12 @@ class Prometheus(Middleware):
 
     def before_process_message(self, broker, message):
         self.message_start_times[message.message_id] = time.monotonic() * 1000
-        self.message_time_in_queue.labels(*self._get_labels(broker, message)).observe(
-            max(current_millis() - message.message_timestamp, 0)
-        )
-        self.worker_busy.set(1)
+        if self.message_time_in_queue is not None:
+            self.message_time_in_queue.labels(*self._get_labels(broker, message)).observe(
+                max(current_millis() - message.message_timestamp, 0)
+            )
+        if self.worker_busy is not None:
+            self.worker_busy.set(1)
 
     def after_process_message(self, broker, message, *, result=None, exception=None):
         labels = self._get_labels(broker, message)
@@ -190,10 +195,11 @@ class Prometheus(Middleware):
         message_duration = 0
         if message_start_time is not None:
             message_duration = (time.monotonic() * 1000) - message_start_time
-        self.message_durations.labels(*labels).observe(message_duration)
-        if exception is not None:
+        if self.message_durations is not None:
+            self.message_durations.labels(*labels).observe(message_duration)
+        if exception is not None and self.total_errored_messages is not None:
             self.total_errored_messages.labels(*labels).inc()
-        if not self.message_start_times:
+        if not self.message_start_times and self.worker_busy is not None:
             self.worker_busy.set(0)
 
     after_skip_message = after_process_message

--- a/remoulade/middleware/retries.py
+++ b/remoulade/middleware/retries.py
@@ -104,9 +104,9 @@ class Retries(Middleware):
             max_retries is not None and retries >= max_retries
         ):
             if max_retries is not None and retries >= max_retries:
-                self.logger.warning(f"Retries exceeded for message {message.message_id}.")
+                self.logger.warning("Retries exceeded for message %s.", message.message_id)
             else:
-                self.logger.warning(f"Message {message.message_id} has failed and will not be retried.")
+                self.logger.warning("Message %s has failed and will not be retried.", message.message_id)
             message.fail()
             return
 

--- a/remoulade/middleware/time_limit.py
+++ b/remoulade/middleware/time_limit.py
@@ -108,7 +108,7 @@ class TimeLimit(Middleware):
             except (SystemExit, KeyboardInterrupt):
                 raise
             except Exception:
-                self.logger.exception("Unhandled error while running soft_kill_handle", exc_info=True)
+                self.logger.exception("Unhandled error while running soft_kill_handle")
 
             time.sleep(self.interval / 1000)
 
@@ -117,7 +117,7 @@ class TimeLimit(Middleware):
             try:
                 self.hard_kill_handle()
             except Exception:
-                self.logger.exception("Unhandled error while running hard_kill_handle", exc_info=True)
+                self.logger.exception("Unhandled error while running hard_kill_handle")
 
             time.sleep(self.interval / 1000)
 
@@ -125,7 +125,7 @@ class TimeLimit(Middleware):
     def actor_options(self) -> set[str]:
         return {"time_limit"}
 
-    def after_process_boot(self, _) -> None:
+    def after_process_boot(self, broker) -> None:
         if current_platform in supported_platforms:
             threading.Thread(target=self.soft_kill_timer, daemon=True).start()
             threading.Thread(target=self.hard_kill_timer, daemon=True).start()

--- a/remoulade/rate_limits/backends/utils.py
+++ b/remoulade/rate_limits/backends/utils.py
@@ -11,11 +11,10 @@ def build_limiter(storage: Storage, *, strategy: str) -> RateLimiter:
     """Return a limits limiter instance for the configured strategy."""
     if strategy == "fixed_window":
         return FixedWindowRateLimiter(storage)
-    elif strategy == "moving_window":
+    if strategy == "moving_window":
         return MovingWindowRateLimiter(storage)
-    elif strategy == "sliding_window":
+    if strategy == "sliding_window":
         return SlidingWindowCounterRateLimiter(storage)
-    else:
-        available_strategies = {"fixed_window", "moving_window", "sliding_window"}
-        available = ", ".join(sorted(available_strategies))
-        raise ValueError(f"Unknown rate limit strategy {strategy!r}. Available: {available}")
+    available_strategies = {"fixed_window", "moving_window", "sliding_window"}
+    available = ", ".join(sorted(available_strategies))
+    raise ValueError(f"Unknown rate limit strategy {strategy!r}. Available: {available}")

--- a/remoulade/result.py
+++ b/remoulade/result.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from typing import Any, Literal, TypeVar, overload
+from typing import Literal, TypeVar, overload
 
 import attr
 
@@ -83,7 +83,27 @@ class Result[R]:
             self.message_id, block=block, timeout=timeout, forget=forget, raise_on_error=raise_on_error
         )
 
-    async def async_get(self, *, timeout: int | None = None, raise_on_error: bool = True, forget: bool = False) -> Any:
+    @overload
+    async def async_get(
+        self,
+        *,
+        timeout: int | None = None,
+        raise_on_error: Literal[True] = True,
+        forget: bool = False,
+    ) -> R: ...
+
+    @overload
+    async def async_get(
+        self,
+        *,
+        timeout: int | None = None,
+        raise_on_error: bool = False,
+        forget: bool = False,
+    ) -> R | ErrorStored: ...
+
+    async def async_get(
+        self, *, timeout: int | None = None, raise_on_error: bool = True, forget: bool = False
+    ) -> R | ErrorStored:
         return await self.backend.async_get_result(
             self.message_id, timeout=timeout, forget=forget, raise_on_error=raise_on_error
         )

--- a/remoulade/results/backend.py
+++ b/remoulade/results/backend.py
@@ -127,14 +127,14 @@ class ResultBackend:
         attempts = 0
         while True:
             result = self._get(message_key, forget)
-            if result is Missing and block:
+            if isinstance(result, dict):
+                backend_result = BackendResult(**result)
+                return self.process_result(backend_result, raise_on_error)
+            if block:
                 delay = self.check_timeout(attempts, end_time, message_id)
                 time.sleep(delay)
-            elif result is Missing:
-                raise ResultMissing(message_id)
             else:
-                backend_result = BackendResult(**result)  # type: ignore
-                return self.process_result(backend_result, raise_on_error)
+                raise ResultMissing(message_id)
 
     async def async_get_result(
         self,
@@ -149,12 +149,12 @@ class ResultBackend:
         attempts = 0
         while True:
             result = self._get(message_key, forget)
-            if result is Missing:
-                delay = self.check_timeout(attempts, end_time, message_id)
-                await asyncio.sleep(delay)
-            else:
-                backend_result = BackendResult(**result)  # type: ignore
+            if isinstance(result, dict):
+                backend_result = BackendResult(**result)
                 return self.process_result(backend_result, raise_on_error)
+
+            delay = self.check_timeout(attempts, end_time, message_id)
+            await asyncio.sleep(delay)
 
     def check_timeout(self, attempts: int, end_time: float, message_id: str) -> float:
         attempts, delay = compute_backoff(attempts, min_backoff=BACKOFF_FACTOR)

--- a/remoulade/results/backend.py
+++ b/remoulade/results/backend.py
@@ -102,7 +102,7 @@ class ResultBackend:
         timeout: int | None = None,
         forget: bool = False,
         raise_on_error: bool = True,
-    ) -> Any:
+    ) -> Any:  # ruff: ignore[ANN401]
         """Get a result from the backend.
 
         Parameters:
@@ -143,7 +143,7 @@ class ResultBackend:
         timeout: int | None = None,
         forget: bool = False,
         raise_on_error: bool = True,
-    ) -> BackendResult:
+    ) -> Any:  # ruff: ignore[ANN401]
         message_key = self.build_message_key(message_id)
         end_time = self.get_end_time(timeout)
         attempts = 0
@@ -261,7 +261,7 @@ class ResultBackend:
         """
         raise NotImplementedError(f"{type(self).__name__} does not implement _get()")
 
-    def _store(self, message_keys: Iterable[str], result: Any, ttl: int) -> None:  # pragma: no cover
+    def _store(self, message_keys: Iterable[str], results: Iterable[Any], ttl: int) -> None:  # pragma: no cover
         """Store multiple results in the backend.  Subclasses may implement
         this method if they want to use the default implementation of
         set_result.

--- a/remoulade/results/backend.py
+++ b/remoulade/results/backend.py
@@ -16,10 +16,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import asyncio
 import time
-from collections import namedtuple
 from collections.abc import Iterable
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, NamedTuple
 
 from ..encoder import Encoder
 from ..helpers import compute_backoff
@@ -38,9 +37,11 @@ class Missing:
 
 
 #: A type alias representing backend results.
-class BackendResult(namedtuple("BackendResult", ("result", "error", "forgot", "actor_name"))):
-    def __new__(cls, *, result, error, forgot=False, actor_name=None):
-        return super().__new__(cls, result, error, forgot, actor_name)
+class BackendResult(NamedTuple):
+    result: Any
+    error: Any
+    forgot: bool = False
+    actor_name: Any = None
 
     def asdict(self):
         return self._asdict()
@@ -60,7 +61,11 @@ class ResultBackend:
     """
 
     def __init__(
-        self, *, namespace: str = "remoulade-results", encoder: Encoder = None, default_timeout: int | None = None
+        self,
+        *,
+        namespace: str = "remoulade-results",
+        encoder: Encoder | None = None,
+        default_timeout: int | None = None,
     ):
         from ..message import get_encoder
 
@@ -158,7 +163,7 @@ class ResultBackend:
             raise ResultTimeout(message_id)
         return delay
 
-    def get_end_time(self, timeout: int) -> float:
+    def get_end_time(self, timeout: int | None = None) -> float:
         if timeout is None:
             timeout = self.default_timeout
         return time.monotonic() + timeout / 1000
@@ -271,15 +276,15 @@ class ResultBackend:
     def retry(self, broker, message, logger):
         try:
             yield
-        except:  # noqa
+        except Exception:
             # If saving the result fail, we must retry the message else we have no way to know it's finished
             # We cannot use the retry middleware as it must be executed before the result middleware,
             # use a simplified one here
             retries = message.options.setdefault("retries_result_backend", 0)
             message.options["retries_result_backend"] = retries + 1
             if retries < 3:
-                logger.warning(f"Could not store result of {message}: retrying it", exc_info=True)
+                logger.warning("Could not store result of %r: retrying it", message, exc_info=True)
                 _, backoff = compute_backoff(retries, min_backoff=500)  # retry after 500ms, 1s, 2s
                 broker.enqueue(message, delay=backoff)
             else:
-                logger.error(f"Could not store result of {message}: retries exceeded", exc_info=True)
+                logger.exception("Could not store result of %r: retrying it", message)

--- a/remoulade/results/backends/local.py
+++ b/remoulade/results/backends/local.py
@@ -1,4 +1,5 @@
 import contextlib
+from collections.abc import Iterable
 from typing import Any, ClassVar
 
 from ..backend import ForgottenResult, Missing, ResultBackend
@@ -24,14 +25,13 @@ class LocalBackend(ResultBackend):
                 data = self.results.pop(message_key)
                 self.forgotten_results.add(message_key)
                 return data
-            else:
-                return self.results[message_key]
+            return self.results[message_key]
         except KeyError:
             return Missing
 
-    def _store(self, message_keys, results, _):
-        for message_key, result in zip(message_keys, results, strict=False):
-            self.results[message_key] = result
+    def _store(self, message_keys: Iterable[str], result: Any, ttl: int) -> None:
+        for message_key, res in zip(message_keys, result, strict=False):
+            self.results[message_key] = res
 
     def _delete(self, key: str):
         with contextlib.suppress(KeyError):

--- a/remoulade/results/backends/local.py
+++ b/remoulade/results/backends/local.py
@@ -29,9 +29,9 @@ class LocalBackend(ResultBackend):
         except KeyError:
             return Missing
 
-    def _store(self, message_keys: Iterable[str], result: Any, ttl: int) -> None:
-        for message_key, res in zip(message_keys, result, strict=False):
-            self.results[message_key] = res
+    def _store(self, message_keys: Iterable[str], results: Iterable[Any], ttl: int) -> None:
+        for message_key, result in zip(message_keys, results, strict=False):
+            self.results[message_key] = result
 
     def _delete(self, key: str):
         with contextlib.suppress(KeyError):

--- a/remoulade/results/backends/redis.py
+++ b/remoulade/results/backends/redis.py
@@ -278,7 +278,8 @@ class RedisBackend(ResultBackend):
             pipe.scard(group_completion_key)
             return pipe.execute()[2]
 
-    def get_status(self, message_ids: list[str]) -> int:  # type: ignore
-        if not message_ids:
+    def get_status(self, message_ids: Iterable[str]) -> int:
+        keys = [self.build_message_key(message_id) for message_id in message_ids]
+        if not keys:
             return 0
-        return self.client.exists(*[self.build_message_key(message_id) for message_id in message_ids])
+        return self.client.exists(*keys)

--- a/remoulade/results/backends/redis.py
+++ b/remoulade/results/backends/redis.py
@@ -253,11 +253,11 @@ class RedisBackend(ResultBackend):
         result = BackendResult(**self.encoder.decode_bytes(data))
         return self.process_result(result, raise_on_error)
 
-    def _store(self, message_keys, result, ttl):
+    def _store(self, message_keys, results, ttl):
         with self.client.pipeline() as pipe:
-            for message_key, res in zip(message_keys, result, strict=False):
+            for message_key, result in zip(message_keys, results, strict=False):
                 pipe.delete(message_key)
-                pipe.lpush(message_key, self.encoder.encode_in_bytes(res))
+                pipe.lpush(message_key, self.encoder.encode_in_bytes(result))
                 pipe.pexpire(message_key, ttl)
             pipe.execute()
 

--- a/remoulade/results/backends/redis.py
+++ b/remoulade/results/backends/redis.py
@@ -211,7 +211,7 @@ class RedisBackend(ResultBackend):
         while data is None:
             try:
                 if block and timeout > 0:
-                    data = self._brpoplpush_with_timeout(message_key, message_key, timeout=timeout)
+                    data = self._brpoplpush_with_timeout(message_key, message_key, timeout=int(timeout))
                     if forget and data is not None:
                         with self.client.pipeline() as pipe:
                             pipe.lpushx(message_key, self.encoder.encode_in_bytes(ForgottenResult.asdict()))
@@ -230,8 +230,7 @@ class RedisBackend(ResultBackend):
                 if data is None:
                     if block:
                         raise ResultTimeout(message_id)
-                    else:
-                        raise ResultMissing(message_id)
+                    raise ResultMissing(message_id)
 
             except (redis.ConnectionError, redis.TimeoutError):
                 # if data is not None, it means the second step of block+forget has failed, we can live without a forget
@@ -254,16 +253,16 @@ class RedisBackend(ResultBackend):
         result = BackendResult(**self.encoder.decode_bytes(data))
         return self.process_result(result, raise_on_error)
 
-    def _store(self, message_keys, results, ttl):
+    def _store(self, message_keys, result, ttl):
         with self.client.pipeline() as pipe:
-            for message_key, result in zip(message_keys, results, strict=False):
+            for message_key, res in zip(message_keys, result, strict=False):
                 pipe.delete(message_key)
-                pipe.lpush(message_key, self.encoder.encode_in_bytes(result))
+                pipe.lpush(message_key, self.encoder.encode_in_bytes(res))
                 pipe.pexpire(message_key, ttl)
             pipe.execute()
 
-    def _get(self, key, forget=False):
-        data = self.client.rpop(key) if forget else self.client.rpoplpush(key, key)
+    def _get(self, message_key, forget=False):
+        data = self.client.rpop(message_key) if forget else self.client.rpoplpush(message_key, message_key)
         if data:
             return self.encoder.decode_bytes(data)
         return Missing
@@ -277,9 +276,7 @@ class RedisBackend(ResultBackend):
             pipe.sadd(group_completion_key, message_id)
             pipe.pexpire(group_completion_key, ttl)
             pipe.scard(group_completion_key)
-            group_completion = pipe.execute()[2]
-
-        return group_completion
+            return pipe.execute()[2]
 
     def get_status(self, message_ids: list[str]) -> int:  # type: ignore
         if not message_ids:

--- a/remoulade/results/backends/stub.py
+++ b/remoulade/results/backends/stub.py
@@ -45,9 +45,9 @@ class StubBackend(ResultBackend):
             return self.encoder.decode_bytes(data)
         return Missing
 
-    def _store(self, message_keys: Iterable[str], result: Any, ttl: int) -> None:
-        for message_key, res in zip(message_keys, result, strict=False):
-            result_data = self.encoder.encode_in_bytes(res)
+    def _store(self, message_keys: Iterable[str], results: Iterable[Any], ttl: int) -> None:
+        for message_key, result in zip(message_keys, results, strict=False):
+            result_data = self.encoder.encode_in_bytes(result)
             expiration = time.monotonic() + int(ttl / 1000)
             self.results[message_key] = (result_data, expiration)
 

--- a/remoulade/results/backends/stub.py
+++ b/remoulade/results/backends/stub.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import contextlib
 import time
+from collections.abc import Iterable
 from typing import Any, ClassVar
 
 from ..backend import ForgottenResult, Missing, ResultBackend
@@ -44,9 +45,9 @@ class StubBackend(ResultBackend):
             return self.encoder.decode_bytes(data)
         return Missing
 
-    def _store(self, message_keys, results, ttl):
-        for message_key, result in zip(message_keys, results, strict=False):
-            result_data = self.encoder.encode_in_bytes(result)
+    def _store(self, message_keys: Iterable[str], result: Any, ttl: int) -> None:
+        for message_key, res in zip(message_keys, result, strict=False):
+            result_data = self.encoder.encode_in_bytes(res)
             expiration = time.monotonic() + int(ttl / 1000)
             self.results[message_key] = (result_data, expiration)
 

--- a/remoulade/results/middleware.py
+++ b/remoulade/results/middleware.py
@@ -76,7 +76,7 @@ class Results(Middleware):
             pipe_on_error: bool = broker.get_middleware(Pipelines).get_option(
                 "pipe_on_error", broker=broker, message=message
             )
-        except:  # noqa
+        except:  # ruff: ignore[E722]
             pipe_on_error = False
 
         results = []
@@ -112,7 +112,7 @@ class Results(Middleware):
                 )
             )
 
-        if results:
+        if results and self.backend is not None:
             message_ids, results_ = zip(*results, strict=False)
             with self.backend.retry(broker, message, self.logger):
                 self.backend.store_results(message_ids, results_, result_ttl)
@@ -121,7 +121,7 @@ class Results(Middleware):
     def _serialize_exception(exception):
         try:
             return repr(exception)
-        except Exception as e:  # noqa
+        except Exception as e:  # ruff: ignore[F841]
             return "Exception could not be serialized"
 
     def _get_children_message_ids(self, broker, pipe_target):
@@ -144,13 +144,14 @@ class Results(Middleware):
 
         return message_ids
 
-    def after_enqueue_pipe_target(self, _, group_info):
+    def after_enqueue_pipe_target(self, broker, group_info):
         """After a pipe target has been enqueued, we need to forget the result of the group (if it's a group)"""
-        if group_info:
+        if group_info and self.backend is not None:
             message_ids = self.backend.get_group_message_ids(group_info.group_id)
             self.backend.forget_results(message_ids, self.result_ttl)
             self.backend.delete_group_message_ids(group_info.group_id)
             self.backend.delete_group_completion(group_info.group_id)
 
-    def before_build_group_pipeline(self, _, group_id, message_ids):
-        self.backend.set_group_message_ids(group_id, message_ids, self.result_ttl)
+    def before_build_group_pipeline(self, broker, group_id, message_ids):
+        if self.backend is not None:
+            self.backend.set_group_message_ids(group_id, message_ids, self.result_ttl)

--- a/remoulade/scheduler/scheduler.py
+++ b/remoulade/scheduler/scheduler.py
@@ -63,7 +63,7 @@ class ScheduledJob:
 
     def get_hash(self) -> str:
         encoder = get_encoder()
-        return hashlib.sha1(  # noqa: S324
+        return hashlib.sha1(  # ruff: ignore[S324]
             "".join(
                 [
                     self.actor_name,
@@ -108,21 +108,21 @@ class ScheduledJob:
 
     @classmethod
     def decode(cls, data: bytes) -> "ScheduledJob":
-        data = get_encoder().decode_bytes(data)
+        payload = get_encoder().decode_bytes(data)
         return ScheduledJob(
-            actor_name=data["actor_name"],
-            interval=data["interval"],
+            actor_name=payload["actor_name"],
+            interval=payload["interval"],
             daily_time=None
-            if data["daily_time"] is None
-            else datetime.datetime.strptime(data["daily_time"], "%H:%M:%S").time(),
-            iso_weekday=data["iso_weekday"],
-            enabled=data["enabled"],
+            if payload["daily_time"] is None
+            else datetime.datetime.strptime(payload["daily_time"], "%H:%M:%S").time(),
+            iso_weekday=payload["iso_weekday"],
+            enabled=payload["enabled"],
             last_queued=None
-            if data["last_queued"] is None
-            else datetime.datetime.strptime(data["last_queued"], "%Y-%m-%dT%H:%M:%S"),
-            tz=data["tz"],
-            args=data["args"],
-            kwargs=data["kwargs"],
+            if payload["last_queued"] is None
+            else datetime.datetime.strptime(payload["last_queued"], "%Y-%m-%dT%H:%M:%S"),
+            tz=payload["tz"],
+            args=payload["args"],
+            kwargs=payload["kwargs"],
         )
 
 
@@ -134,8 +134,8 @@ class Scheduler:
         *,
         namespace: str | None = None,
         lock_key: str | None = None,
-        period: int | float | None = None,
-        client: redis.Redis = None,
+        period: float | None = None,
+        client: redis.Redis | None = None,
         url: str | None = None,
         **redis_parameters,
     ) -> None:
@@ -245,7 +245,7 @@ class Scheduler:
                             continue
 
                     if job.actor_name not in self.broker.actors:
-                        self.logger.error(f"Unknown {job_hash}. Cannot queue it.")
+                        self.logger.error("Unknown %s. Cannot queue it.", job_hash)
                         continue
 
                     self.broker.actors[job.actor_name].send(*job.args, **job.kwargs)

--- a/remoulade/state/backend.py
+++ b/remoulade/state/backend.py
@@ -30,19 +30,19 @@ class State:
         args: List of arguments in the state
     """
 
-    message_id: Any
-    status: Any = None
-    actor_name: Any = None
-    args: Any = None
-    kwargs: Any = None
-    options: Any = None
-    priority: Any = None
-    progress: Any = None
-    enqueued_datetime: Any = None
-    started_datetime: Any = None
-    end_datetime: Any = None
-    queue_name: Any = None
-    composition_id: Any = None
+    message_id: str
+    status: StateStatusesEnum | None = None
+    actor_name: str | None = None
+    args: list[Any] | None = None
+    kwargs: dict[str, Any] | None = None
+    options: dict[str, Any] | None = None
+    priority: int | None = None
+    progress: float | None = None
+    enqueued_datetime: datetime.datetime | None = None
+    started_datetime: datetime.datetime | None = None
+    end_datetime: datetime.datetime | None = None
+    queue_name: str | None = None
+    composition_id: str | None = None
 
     def __post_init__(self):
         if self.status and self.status not in list(StateStatusesEnum):

--- a/remoulade/state/backend.py
+++ b/remoulade/state/backend.py
@@ -1,7 +1,8 @@
 import datetime
 import sys
-from collections import namedtuple
+from dataclasses import asdict, dataclass
 from enum import Enum
+from typing import Any
 
 from dateutil.parser import parse
 
@@ -21,88 +22,52 @@ class StateStatusesEnum(Enum):
 
 
 #: A type alias representing states in the database
-class State(
-    namedtuple(
-        "State",
-        (
-            "message_id",
-            "status",
-            "actor_name",
-            "args",
-            "kwargs",
-            "options",
-            "priority",
-            "progress",
-            "enqueued_datetime",
-            "started_datetime",
-            "end_datetime",
-            "queue_name",
-            "composition_id",
-        ),
-    )
-):
+@dataclass(frozen=True)
+class State:
     """Catalog Class, it storages the state
     Parameters:
         status: The current status of the message state
         args: List of arguments in the state
     """
 
-    def __new__(
-        cls,
-        message_id,
-        status=None,
-        *,
-        actor_name=None,
-        args=None,
-        kwargs=None,
-        options=None,
-        priority=None,
-        progress=None,
-        enqueued_datetime=None,
-        started_datetime=None,
-        end_datetime=None,
-        queue_name=None,
-        composition_id=None,
-    ):
-        if status and status not in list(StateStatusesEnum):
-            raise InvalidStateError(f"The {status} State is not defined")
-        return super().__new__(
-            cls,
-            message_id,
-            status,
-            actor_name,
-            args,
-            kwargs,
-            options,
-            priority,
-            progress,
-            enqueued_datetime,
-            started_datetime,
-            end_datetime,
-            queue_name,
-            composition_id,
-        )
+    message_id: Any
+    status: Any = None
+    actor_name: Any = None
+    args: Any = None
+    kwargs: Any = None
+    options: Any = None
+    priority: Any = None
+    progress: Any = None
+    enqueued_datetime: Any = None
+    started_datetime: Any = None
+    end_datetime: Any = None
+    queue_name: Any = None
+    composition_id: Any = None
+
+    def __post_init__(self):
+        if self.status and self.status not in list(StateStatusesEnum):
+            raise InvalidStateError(f"The {self.status} State is not defined")
 
     def as_dict(self, exclude_keys=(), encode_args=False):
         """Transform a State into a dict, can exclude some keys"""
-        as_dict = {
-            key: value for (key, value) in self._asdict().items() if value is not None and key not in exclude_keys
+        as_dict_repr = {
+            key: value for (key, value) in asdict(self).items() if value is not None and key not in exclude_keys
         }
         datetime_keys = ["enqueued_datetime", "started_datetime", "end_datetime"]
         for key in datetime_keys:
-            if key in as_dict:
-                as_dict[key] = as_dict[key].isoformat()
+            if key in as_dict_repr:
+                as_dict_repr[key] = as_dict_repr[key].isoformat()
         if self.status:
-            as_dict["status"] = self.status.value
+            as_dict_repr["status"] = self.status.value
         if encode_args:
             from ..message import get_encoder
 
-            for key in (item for item in ["args", "kwargs", "options"] if item in as_dict):
+            for key in (item for item in ["args", "kwargs", "options"] if item in as_dict_repr):
                 try:
-                    as_dict[key] = get_encoder().encode_in_bytes(as_dict[key]).decode("utf-8")
+                    as_dict_repr[key] = get_encoder().encode_in_bytes(as_dict_repr[key]).decode("utf-8")
                 except (UnicodeDecodeError, TypeError):
-                    as_dict[key] = "encoded_data"
-        return as_dict
+                    as_dict_repr[key] = "encoded_data"
+        return as_dict_repr
 
     @classmethod
     def from_dict(cls, input_dict: dict) -> "State":
@@ -129,7 +94,7 @@ class StateBackend:
 
     namespace = "remoulade-state*"
 
-    def __init__(self, *, namespace: str = "remoulade-state", encoder: Encoder = None, max_size=2e6):
+    def __init__(self, *, namespace: str = "remoulade-state", encoder: Encoder | None = None, max_size=2e6):
         from ..message import get_encoder
 
         self.namespace = namespace

--- a/remoulade/state/backend.py
+++ b/remoulade/state/backend.py
@@ -53,9 +53,8 @@ class State:
 
     def as_dict(self, exclude_keys=(), encode_args=False):
         """Transform a State into a dict, can exclude some keys"""
-        as_dict_repr = {
-            key: value for (key, value) in asdict(self).items() if value is not None and key not in exclude_keys
-        }
+        exclude = {"delivery_id", *exclude_keys}
+        as_dict_repr = {key: value for (key, value) in asdict(self).items() if value is not None and key not in exclude}
         datetime_keys = ["enqueued_datetime", "started_datetime", "end_datetime"]
         for key in datetime_keys:
             if key in as_dict_repr:
@@ -130,7 +129,7 @@ class StateBackend:
         """
         raise NotImplementedError(f"{type(self).__name__} does not implement get_state")
 
-    def set_state(self, state: State, ttl: int = 3600) -> None:
+    def set_state(self, state: State, ttl: int | None = 3600) -> None:
         """Save a message in the backend if it does not exist,
             otherwise update it.
 

--- a/remoulade/state/backend.py
+++ b/remoulade/state/backend.py
@@ -1,8 +1,8 @@
 import datetime
 import sys
-from collections import namedtuple
+from dataclasses import asdict, dataclass
 from enum import Enum
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from dateutil.parser import parse
 
@@ -22,26 +22,8 @@ class StateStatusesEnum(Enum):
 
 
 #: A type alias representing states in the database
-class State(
-    namedtuple(
-        "State",
-        (
-            "message_id",
-            "status",
-            "actor_name",
-            "args",
-            "kwargs",
-            "options",
-            "priority",
-            "progress",
-            "enqueued_datetime",
-            "started_datetime",
-            "end_datetime",
-            "queue_name",
-            "composition_id",
-        ),
-    )
-):
+@dataclass(frozen=True)
+class State:
     """Catalog Class, it storages the state
     Parameters:
         status: The current status of the message state
@@ -50,67 +32,45 @@ class State(
             when it has one. A retry gets a new one, unlike message_id.
     """
 
+    message_id: Any
+    status: Any = None
+    actor_name: Any = None
+    args: Any = None
+    kwargs: Any = None
+    options: Any = None
+    priority: Any = None
+    progress: Any = None
+    enqueued_datetime: Any = None
+    started_datetime: Any = None
+    end_datetime: Any = None
+    queue_name: Any = None
+    composition_id: Any = None
     delivery_id: int | None = None
 
-    def __new__(
-        cls,
-        message_id,
-        status=None,
-        *,
-        actor_name=None,
-        args=None,
-        kwargs=None,
-        options=None,
-        priority=None,
-        progress=None,
-        enqueued_datetime=None,
-        started_datetime=None,
-        end_datetime=None,
-        queue_name=None,
-        composition_id=None,
-        delivery_id=None,
-    ):
-        if status and status not in list(StateStatusesEnum):
-            raise InvalidStateError(f"The {status} State is not defined")
-        state = super().__new__(
-            cls,
-            message_id,
-            status,
-            actor_name,
-            args,
-            kwargs,
-            options,
-            priority,
-            progress,
-            enqueued_datetime,
-            started_datetime,
-            end_datetime,
-            queue_name,
-            composition_id,
-        )
-        state.delivery_id = delivery_id
-        return state
+    def __post_init__(self):
+        if self.status and self.status not in list(StateStatusesEnum):
+            raise InvalidStateError(f"The {self.status} State is not defined")
 
     def as_dict(self, exclude_keys=(), encode_args=False):
         """Transform a State into a dict, can exclude some keys"""
-        as_dict = {
-            key: value for (key, value) in self._asdict().items() if value is not None and key not in exclude_keys
+        as_dict_repr = {
+            key: value for (key, value) in asdict(self).items() if value is not None and key not in exclude_keys
         }
         datetime_keys = ["enqueued_datetime", "started_datetime", "end_datetime"]
         for key in datetime_keys:
-            if key in as_dict:
-                as_dict[key] = as_dict[key].isoformat()
+            if key in as_dict_repr:
+                as_dict_repr[key] = as_dict_repr[key].isoformat()
         if self.status:
-            as_dict["status"] = self.status.value
+            as_dict_repr["status"] = self.status.value
         if encode_args:
             from ..message import get_encoder
 
-            for key in (item for item in ["args", "kwargs", "options"] if item in as_dict):
+            for key in (item for item in ["args", "kwargs", "options"] if item in as_dict_repr):
                 try:
-                    as_dict[key] = get_encoder().encode_in_bytes(as_dict[key]).decode("utf-8")
+                    as_dict_repr[key] = get_encoder().encode_in_bytes(as_dict_repr[key]).decode("utf-8")
                 except (UnicodeDecodeError, TypeError):
-                    as_dict[key] = "encoded_data"
-        return as_dict
+                    as_dict_repr[key] = "encoded_data"
+        return as_dict_repr
 
     @classmethod
     def from_dict(cls, input_dict: dict) -> "State":
@@ -143,7 +103,7 @@ class StateBackend:
     namespace = "remoulade-state*"
     requires_ttl: ClassVar[bool] = True
 
-    def __init__(self, *, namespace: str = "remoulade-state", encoder: Encoder = None, max_size=2e6):
+    def __init__(self, *, namespace: str = "remoulade-state", encoder: Encoder | None = None, max_size=2e6):
         from ..message import get_encoder
 
         self.namespace = namespace

--- a/remoulade/state/backend.py
+++ b/remoulade/state/backend.py
@@ -32,19 +32,19 @@ class State:
             when it has one. A retry gets a new one, unlike message_id.
     """
 
-    message_id: Any
-    status: Any = None
-    actor_name: Any = None
-    args: Any = None
-    kwargs: Any = None
-    options: Any = None
-    priority: Any = None
-    progress: Any = None
-    enqueued_datetime: Any = None
-    started_datetime: Any = None
-    end_datetime: Any = None
-    queue_name: Any = None
-    composition_id: Any = None
+    message_id: str
+    status: StateStatusesEnum | None = None
+    actor_name: str | None = None
+    args: list[Any] | None = None
+    kwargs: dict[str, Any] | None = None
+    options: dict[str, Any] | None = None
+    priority: int | None = None
+    progress: float | None = None
+    enqueued_datetime: datetime.datetime | None = None
+    started_datetime: datetime.datetime | None = None
+    end_datetime: datetime.datetime | None = None
+    queue_name: str | None = None
+    composition_id: str | None = None
     delivery_id: int | None = None
 
     def __post_init__(self):

--- a/remoulade/state/backends/postgres.py
+++ b/remoulade/state/backends/postgres.py
@@ -98,7 +98,7 @@ class PostgresBackend(StateBackend):
         self.broker = broker
 
     @override
-    def set_state(self, state: State, ttl: int = 3600) -> None:
+    def set_state(self, state: State, ttl: int | None = 3600) -> None:
         """Record ``state``'s status on the pgmq row it was observed on.
 
         One ``UPDATE`` on the broker's queue table, on top of the archive that
@@ -108,14 +108,14 @@ class PostgresBackend(StateBackend):
         if state.status not in TERMINAL_STATUSES:
             return
 
-        if state.delivery_id is None:
+        if state.delivery_id is None or state.queue_name is None:
             # Every in-flight hook reports a MessageProxy, so a terminal status with no
             # delivery id comes from the enqueue hooks, where MessageState only records
             # a Failure. Any other status here means the state was built by hand.
             if state.status is not StateStatusesEnum.Failure:
                 self.broker.logger.warning(
-                    "Could not record status %s for message %s: it carries no delivery_id, so there is no pgmq "
-                    "row to record it on.",
+                    "Could not record status %s for message %s: it carries no delivery_id or queue_name, "
+                    "so there is no pgmq row to record it on.",
                     state.status.value,
                     state.message_id,
                 )

--- a/remoulade/state/backends/redis.py
+++ b/remoulade/state/backends/redis.py
@@ -57,12 +57,23 @@ class RedisBackend(StateBackend):
         sort_direction: str | None = None,
     ):
         states: list[State] = []
-        for keys in chunk(self.client.scan_iter(match=f"{StateBackend.namespace}*", count=size), size):
-            with self.client.pipeline() as pipe:
-                for key in keys:
-                    pipe.hgetall(key)
-                data = pipe.execute()
-                states.extend(self._parse_state(state_dict) for state_dict in data if state_dict)
+        pattern = f"{StateBackend.namespace}*"
+
+        if size is not None:
+            for keys in chunk(self.client.scan_iter(match=pattern, count=size), size):
+                with self.client.pipeline() as pipe:
+                    for key in keys:
+                        pipe.hgetall(key)
+                    data = pipe.execute()
+                    states.extend(self._parse_state(state_dict) for state_dict in data if state_dict)
+        else:
+            keys = list(self.client.scan_iter(match=pattern))
+            if keys:
+                with self.client.pipeline() as pipe:
+                    for key in keys:
+                        pipe.hgetall(key)
+                    data = pipe.execute()
+                    states.extend(self._parse_state(state_dict) for state_dict in data if state_dict)
 
         if size is None:
             return states[offset:]

--- a/remoulade/state/backends/stub.py
+++ b/remoulade/state/backends/stub.py
@@ -1,5 +1,6 @@
 import datetime
 import time
+from typing import Any
 
 from ..backend import State, StateBackend
 
@@ -14,7 +15,7 @@ class StubBackend(StateBackend):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.states: dict[str, dict[str, str]] = {}
+        self.states: dict[str, dict[str, Any]] = {}
 
     def get_state(self, message_id):
         message_key = self._build_message_key(message_id)

--- a/remoulade/worker.py
+++ b/remoulade/worker.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING
 
 from .cancel import MessageCanceled
 from .common import current_millis
-from .errors import ActorNotFound, ConnectionError, RemouladeError  # noqa: A004
+from .errors import ActorNotFound, ConnectionError, RemouladeError  # ruff: ignore[A004]
 from .helpers import compute_backoff
 from .helpers.queues import iter_queue, join_all, q_name
 from .logging import get_logger
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 
 #: The number of try to restart consumers (with exponential backoff) after a connection error
 #: 0 to disable consumer restart and exit with an error
-CONSUMER_RESTART_MAX_RETRIES = int(os.getenv("remoulade_restart_max_retries", 10))  # noqa: SIM112
+CONSUMER_RESTART_MAX_RETRIES = int(os.getenv("remoulade_restart_max_retries", 10))  # ruff: ignore[SIM112]
 
 
 def build_extra(message, max_input_size: int | None = None):
@@ -146,7 +146,11 @@ class Worker:
             try:
                 self.consumers[queue_name].requeue_messages(messages)
             except ConnectionError:
-                self.logger.warning(f"Failed to requeue messages on queue {queue_name}.", exc_info=True)
+                self.logger.warning(
+                    "Failed to requeue messages on queue %s.",
+                    queue_name,
+                    exc_info=True,
+                )
         self.logger.debug("Done requeueing in-progress messages.")
 
         self.logger.debug("Closing consumers...")
@@ -333,10 +337,9 @@ class _ConsumerThread(Thread):
                 self.logger.debug("Pushing message %r onto work queue.", message.message_id)
                 self.work_queue.put((-actor.priority, message))
         except ActorNotFound:
-            self.logger.error(
+            self.logger.exception(
                 "Received message for undefined actor %r. Moving it to the DLQ.",
                 message.actor_name,
-                exc_info=True,
             )
             message.fail()
             self.post_process_message(message)
@@ -349,13 +352,15 @@ class _ConsumerThread(Thread):
         if message.failed:
             self.logger.debug("Rejecting message %r.", message.message_id)
             self.broker.emit_before("nack", message)
-            self.consumer.nack(message)
+            if self.consumer is not None:
+                self.consumer.nack(message)
             self.broker.emit_after("nack", message)
 
         else:
             self.logger.debug("Acknowledging message %r.", message.message_id)
             self.broker.emit_before("ack", message)
-            self.consumer.ack(message)
+            if self.consumer is not None:
+                self.consumer.ack(message)
             self.broker.emit_after("ack", message)
 
     def requeue_messages(self, messages):
@@ -363,7 +368,8 @@ class _ConsumerThread(Thread):
         connection error to move unacked messages back to their
         respective queues asap.
         """
-        self.consumer.requeue(messages)
+        if self.consumer is not None:
+            self.consumer.requeue(messages)
 
     def pause(self):
         """Pause this consumer."""

--- a/remoulade/worker.py
+++ b/remoulade/worker.py
@@ -90,7 +90,7 @@ class Worker:
         self.delay_prefetch = min(worker_threads * 1000, 65535)
 
         self.workers = []
-        self.work_queue = PriorityQueue()  # type: PriorityQueue
+        self.work_queue = PriorityQueue()
         self.worker_timeout = worker_timeout
         self.worker_threads = worker_threads
 
@@ -245,7 +245,7 @@ class _ConsumerThread(Thread):
         self.queue_name = queue_name
         self.work_queue = work_queue
         self.worker_timeout = worker_timeout
-        self.delay_queue = PriorityQueue()  # type: PriorityQueue
+        self.delay_queue = PriorityQueue()
 
     def run(self):
         self.logger.debug("Running consumer thread...")

--- a/tests/concurrent/test_redis_backend.py
+++ b/tests/concurrent/test_redis_backend.py
@@ -1,5 +1,5 @@
-# ruff: noqa: S106
-# ruff: noqa: S105
+# ruff: file-ignore[S105]
+# ruff: file-ignore[S106]
 import time
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,8 +190,7 @@ def start_cli():
 @pytest.fixture
 def scheduler_thread():
     scheduler = remoulade.get_scheduler()
-    thread = threading.Thread(target=scheduler.start)
-    yield thread
+    yield threading.Thread(target=scheduler.start)
     scheduler.stop()
 
 

--- a/tests/helpers/test_helpers.py
+++ b/tests/helpers/test_helpers.py
@@ -114,7 +114,7 @@ def test_join_queue_gevent_style_timeout_raises_queue_join_timeout():
 def test_join_queue_gevent_style_success():
     queue = _GeventStyleQueue(result=True)
     join_queue(queue, timeout=0.1)
-    assert queue.received_timeout == 0.1
+    assert queue.received_timeout == pytest.approx(0.1)
 
 
 def test_join_queue_stdlib_fallback_success():

--- a/tests/helpers/test_postgres_client.py
+++ b/tests/helpers/test_postgres_client.py
@@ -151,6 +151,7 @@ def test_postgres_broker_declares_no_queue_it_cannot_name():
     broker.client.create_partitioned_queue = Mock()
     broker.client.enable_notify = Mock()
     broker.client.list_queues = Mock(return_value=[])
+    assert broker.client.engine is not None
     broker.client.engine.begin = MagicMock()
 
     with pytest.raises(ValueError, match="not a usable queue name"):

--- a/tests/middleware/test_catch_error.py
+++ b/tests/middleware/test_catch_error.py
@@ -13,7 +13,7 @@ def test_on_failure(stub_broker, stub_worker):
 
     @remoulade.actor
     def fail_actor():
-        raise Exception()
+        raise Exception
 
     remoulade.declare_actors([on_failure, fail_actor])
 
@@ -37,7 +37,7 @@ def test_on_failure_message(stub_broker, stub_worker):
 
     @remoulade.actor
     def fail_actor():
-        raise Exception()
+        raise Exception
 
     remoulade.declare_actors([on_failure, fail_actor])
 
@@ -63,7 +63,7 @@ def test_on_failure_message_in_actor_options(stub_broker, stub_worker):
 
     @remoulade.actor(on_failure=on_failure.message())
     def fail_actor():
-        raise Exception()
+        raise Exception
 
     stub_broker.declare_actor(fail_actor)
 
@@ -86,7 +86,7 @@ def test_on_failure_runs_only_once(stub_broker, stub_worker):
 
     @remoulade.actor
     def fail_actor():
-        raise Exception()
+        raise Exception
 
     remoulade.declare_actors([on_failure, fail_actor])
 

--- a/tests/middleware/test_current_message.py
+++ b/tests/middleware/test_current_message.py
@@ -12,7 +12,8 @@ class TestCurrentMessage:
         @remoulade.actor
         def do_work():
             msg = CurrentMessage.get_current_message()
-            message_ids.add(msg.message_id)
+            if msg is not None:
+                message_ids.add(msg.message_id)
 
         stub_broker.declare_actor(do_work)
         messages = [do_work.send() for _ in range(20)]

--- a/tests/middleware/test_heartbeat.py
+++ b/tests/middleware/test_heartbeat.py
@@ -37,7 +37,7 @@ def _build_url(heartbeat: Heartbeat, query: str = "") -> str:
 
 def _get_status(url: str) -> int:
     try:
-        with request.urlopen(url, timeout=1) as response:  # noqa: S310
+        with request.urlopen(url, timeout=1) as response:  # ruff: ignore[S310]
             return response.getcode()
     except error.HTTPError as exc:
         return exc.code
@@ -152,7 +152,7 @@ def test_heartbeat_server_shuts_down_cleanly(stub_broker: StubBroker):
             url = _build_url(heartbeat)
 
         with pytest.raises(error.URLError):
-            request.urlopen(url, timeout=1)  # noqa: S310
+            request.urlopen(url, timeout=1)  # ruff: ignore[S310]
 
 
 def test_healthy_returns_false_when_any_worker_thread_is_stale():

--- a/tests/middleware/test_message_state.py
+++ b/tests/middleware/test_message_state.py
@@ -61,7 +61,7 @@ class TestMessageState:
     def test_failure_state_message(self, stub_broker, state_middleware, stub_worker, frozen_datetime):
         @remoulade.actor
         def error():
-            raise Exception()
+            raise Exception
 
         remoulade.declare_actors([error])
         msg = error.send()
@@ -89,7 +89,7 @@ class TestMessageState:
     def test_skip_state_message(self, stub_broker, stub_worker, state_middleware, do_work):
         class SkipMiddleware(Middleware):
             def before_process_message(self, broker, message):
-                raise SkipMessage()
+                raise SkipMessage
 
         stub_broker.add_middleware(SkipMiddleware())
         msg = do_work.send()

--- a/tests/middleware/test_message_state.py
+++ b/tests/middleware/test_message_state.py
@@ -62,7 +62,7 @@ class TestMessageState:
     def test_failure_state_message(self, stub_broker, state_middleware, stub_worker, frozen_datetime):
         @remoulade.actor
         def error():
-            raise Exception()
+            raise Exception
 
         remoulade.declare_actors([error])
         msg = error.send()
@@ -90,7 +90,7 @@ class TestMessageState:
     def test_skip_state_message(self, stub_broker, stub_worker, state_middleware, do_work):
         class SkipMiddleware(Middleware):
             def before_process_message(self, broker, message):
-                raise SkipMessage()
+                raise SkipMessage
 
         stub_broker.add_middleware(SkipMiddleware())
         msg = do_work.send()

--- a/tests/middleware/test_shutdown.py
+++ b/tests/middleware/test_shutdown.py
@@ -35,7 +35,7 @@ def test_shutdown_notifications_worker_shutdown_messages(raise_thread_exception,
 
     # Given a middleware with two "threads"
     middleware = shutdown.ShutdownNotifications()
-    middleware.notifications = [1, 2]
+    middleware.notifications = {1, 2}
 
     # Given a broker configured with the shutdown notifier
     broker = StubBroker(middleware=[middleware])

--- a/tests/middleware/test_time_limit.py
+++ b/tests/middleware/test_time_limit.py
@@ -23,7 +23,7 @@ from remoulade.middleware import TimeLimit, TimeLimitExceeded
 
 @mock.patch("os._exit")
 @mock.patch("remoulade.middleware.time_limit.raise_thread_exception")
-def test_time_limit_soft(raise_thread_exception, exit, stub_broker, stub_worker, do_work):  # noqa: A002
+def test_time_limit_soft(raise_thread_exception, exit, stub_broker, stub_worker, do_work):  # ruff: ignore[A002]
     @remoulade.actor(time_limit=1)
     def do_work():
         time.sleep(1)
@@ -33,9 +33,9 @@ def test_time_limit_soft(raise_thread_exception, exit, stub_broker, stub_worker,
     # With a TimeLimit middleware
     for middleware in stub_broker.middleware:
         if isinstance(middleware, TimeLimit):
-            # That emit a signal every ms and stop after 15ms
+            # That emit a signal every ms and stop after 50ms
             middleware.interval = 1
-            middleware.time_limit = 15
+            middleware.time_limit = 50
             middleware.exit_delay = 0
 
     # When I send it a message

--- a/tests/state/test_postgres_backend.py
+++ b/tests/state/test_postgres_backend.py
@@ -38,7 +38,7 @@ def _archived_rows(broker, queue_name="default"):
     with broker.client.engine.begin() as connection:
         return connection.execute(
             text(
-                f"SELECT msg_id, read_ct, headers, archived_at, message->>'message_id' AS message_id "  # noqa: S608
+                f"SELECT msg_id, read_ct, headers, archived_at, message->>'message_id' AS message_id "  # ruff: ignore[S608]
                 f'FROM pgmq."a_{queue_name}" ORDER BY msg_id'
             )
         ).all()
@@ -166,7 +166,7 @@ class TestTerminalStates:
 
         @remoulade.actor
         def skipper():
-            raise SkipMessage()
+            raise SkipMessage
 
         postgres_broker.declare_actor(skipper)
         message = skipper.send()
@@ -303,7 +303,9 @@ class TestProgress:
         @remoulade.actor(max_retries=0)
         def reporting():
             for step in (0.25, 0.5, 1):
-                CurrentMessage.get_current_message().set_progress(step)
+                msg = CurrentMessage.get_current_message()
+                assert msg is not None
+                msg.set_progress(step)
                 reported.append(step)
 
         postgres_broker.declare_actor(reporting)
@@ -323,7 +325,7 @@ class TestConfiguration:
         # Without it the backend could only resolve one later, and a
         # misconfiguration would surface as silently missing states.
         with pytest.raises(TypeError):
-            PostgresBackend()  # type: ignore[call-arg]
+            PostgresBackend()  # ty: ignore[missing-argument]
 
     def test_keeps_the_broker_it_was_given(self, postgres_broker):
         assert PostgresBackend(postgres_broker).broker is postgres_broker

--- a/tests/state/test_progress_message.py
+++ b/tests/state/test_progress_message.py
@@ -18,8 +18,9 @@ class TestProgressMessage:
         def do_work():
             msg = CurrentMessage.get_current_message()
             progress = random.uniform(0, 1)
-            msg.set_progress(progress)
-            progress_messages[msg.message_id] = progress
+            if msg is not None:
+                msg.set_progress(progress)
+                progress_messages[msg.message_id] = progress
 
         stub_broker.declare_actor(do_work)
 
@@ -38,7 +39,8 @@ class TestProgressMessage:
         def do_work():
             try:
                 msg = CurrentMessage.get_current_message()
-                msg.set_progress(progress)
+                if msg is not None:
+                    msg.set_progress(progress)
             except InvalidProgress:
                 error.append(True)
 

--- a/tests/state/test_state_api.py
+++ b/tests/state/test_state_api.py
@@ -3,6 +3,7 @@ import json
 from datetime import date
 from operator import itemgetter
 from random import choice
+from typing import Any, cast
 from unittest import mock
 from unittest.mock import MagicMock
 from zoneinfo import ZoneInfo
@@ -82,7 +83,7 @@ class TestMessageStateAPI:
         assert res.status_code == 500
 
     def test_no_scheduler(self, stub_broker, api_client):
-        set_scheduler(None)
+        set_scheduler(cast("Any", None))
         res = api_client.get("/scheduled/jobs")
         assert res.status_code == 400
 
@@ -196,7 +197,7 @@ class TestMessageStateAPI:
 
     @pytest.mark.parametrize("offset", [0, 1, 5, 100])
     def test_get_states_offset(self, offset, stub_broker, api_client, state_middleware):
-        for i in range(0, 10):
+        for i in range(10):
             state_middleware.backend.set_state(State(f"id{i}"), ttl=1000)
         res = api_client.post(
             "/messages/states", data=json.dumps({"offset": offset, "size": 50}), content_type="application/json"
@@ -208,7 +209,7 @@ class TestMessageStateAPI:
 
     @pytest.mark.parametrize("size", [1, 5, 100])
     def test_get_states_page_size(self, size, stub_broker, api_client, state_middleware):
-        for i in range(0, 10):
+        for i in range(10):
             state_middleware.backend.set_state(State(f"id{i}"), ttl=1000)
         res = api_client.post("/messages/states", data=json.dumps({"size": size}), content_type="application/json")
         if size >= 10:

--- a/tests/state/test_state_api.py
+++ b/tests/state/test_state_api.py
@@ -3,6 +3,7 @@ import json
 from datetime import date
 from operator import itemgetter
 from random import choice
+from typing import Any, cast
 from unittest import mock
 from unittest.mock import MagicMock
 from zoneinfo import ZoneInfo
@@ -93,7 +94,7 @@ class TestMessageStateAPI:
         assert res.status_code == 500
 
     def test_no_scheduler(self, stub_broker, api_client):
-        set_scheduler(None)
+        set_scheduler(cast("Any", None))
         res = api_client.get("/scheduled/jobs")
         assert res.status_code == 400
 
@@ -207,7 +208,7 @@ class TestMessageStateAPI:
 
     @pytest.mark.parametrize("offset", [0, 1, 5, 100])
     def test_get_states_offset(self, offset, stub_broker, api_client, state_middleware):
-        for i in range(0, 10):
+        for i in range(10):
             state_middleware.backend.set_state(State(f"id{i}"), ttl=1000)
         res = api_client.post(
             "/messages/states", data=json.dumps({"offset": offset, "size": 50}), content_type="application/json"
@@ -219,7 +220,7 @@ class TestMessageStateAPI:
 
     @pytest.mark.parametrize("size", [1, 5, 100])
     def test_get_states_page_size(self, size, stub_broker, api_client, state_middleware):
-        for i in range(0, 10):
+        for i in range(10):
             state_middleware.backend.set_state(State(f"id{i}"), ttl=1000)
         res = api_client.post("/messages/states", data=json.dumps({"size": size}), content_type="application/json")
         if size >= 10:

--- a/tests/test_actors.py
+++ b/tests/test_actors.py
@@ -205,8 +205,7 @@ def test_actors_retry_on_failure(stub_broker, stub_worker, caplog):
         if sum(failures) == 0:
             failures.append(1)
             raise RuntimeError("First failure.")
-        else:
-            successes.append(1)
+        successes.append(1)
 
     # test log
 
@@ -476,7 +475,7 @@ def test_middleware_can_decide_to_skip_messages(stub_broker, stub_worker):
 
     class SkipMiddleware(Middleware):
         def before_process_message(self, broker, message):
-            raise SkipMessage()
+            raise SkipMessage
 
         def after_skip_message(self, broker, message):
             skipped_messages.append(1)

--- a/tests/test_actors.py
+++ b/tests/test_actors.py
@@ -292,7 +292,7 @@ def test_actors_age_limit_exception(stub_broker, stub_worker, result_backend):
     stub_broker.declare_actor(do_sleep)
     stub_broker.declare_actor(do_raise)
 
-    p = remoulade.pipeline([do_sleep.message(), do_raise.message()])
+    p = remoulade.pipeline([do_sleep.message(), do_raise.message()])  # ty: ignore[no-matching-overload]
     p.run()
 
     # And join on the queue
@@ -300,7 +300,7 @@ def test_actors_age_limit_exception(stub_broker, stub_worker, result_backend):
     stub_broker.join(do_raise.queue_name)
     stub_worker.join()
 
-    err = p.result.get(block=True, raise_on_error=False)
+    err = p.result.get(block=True, raise_on_error=False)  # ty: ignore[no-matching-overload]
 
     assert "AgeLimitException" in err.message
 

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -140,7 +140,7 @@ def test_cancel_pipeline_or_groups(stub_broker, stub_worker, cancel_backend, wit
     @remoulade.actor()
     def do_work():
         has_been_called.append(1)
-        raise ValueError()
+        raise ValueError
 
     # And this actor is declared
     stub_broker.declare_actor(do_work)
@@ -170,7 +170,7 @@ def test_composition_can_be_canceled(stub_broker, stub_worker, cancel_backend):
     def do_work():
         nonlocal calls_count
         calls_count += 1
-        raise ValueError()
+        raise ValueError
 
     # And this actor is declared
     stub_broker.declare_actor(do_work)

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -1,3 +1,5 @@
+# ty: ignore[no-matching-overload]
+
 from unittest.mock import patch
 
 import pytest
@@ -154,7 +156,7 @@ def test_cancel_pipeline_or_groups(stub_broker, stub_worker, cancel_backend, wit
     stub_worker.join()
 
     # All actors should have been canceled
-    assert all(cancel_backend.is_canceled(child.message_id, None) for child in g.children)
+    assert all(cancel_backend.is_canceled(child.message_id, None) for child in g.children)  # ty: ignore[unresolved-attribute]
     assert len(has_been_called) == 0
 
 

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1,3 +1,5 @@
+# ty: ignore[no-matching-overload, invalid-argument-type, unresolved-attribute]
+
 import threading
 import time
 from threading import Condition

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -187,7 +187,7 @@ def test_pipelines_expose_completion_stats(stub_broker, stub_worker, result_back
     pipe.run()
 
     # Then every time a job in the pipeline completes, the completed_count should increase
-    for count in range(0, len(pipe)):
+    for count in range(len(pipe)):
         event_count[count].set()
         event_result.wait(2)
         event_result.clear()
@@ -227,7 +227,7 @@ def test_pipelines_store_results_error(stub_broker, result_backend, stub_worker,
     # Given an actor that fail
     @remoulade.actor(store_results=store_results)
     def do_work_fail():
-        raise ValueError()
+        raise ValueError
 
     # Given an actor that stores results
     @remoulade.actor(store_results=True)

--- a/tests/test_generic_actors.py
+++ b/tests/test_generic_actors.py
@@ -13,7 +13,7 @@ def test_generic_actors_can_be_defined(stub_broker):
     assert isinstance(Add.__actor__, remoulade.Actor)
 
     # And it should be callable
-    assert Add(1, 2) == 3
+    assert Add(1, 2) == 3  # ty: ignore[too-many-positional-arguments]
 
 
 def test_generic_actors_can_be_assigned_options(stub_broker):
@@ -118,7 +118,7 @@ def test_generic_actors_can_inherite_meta(stub_broker, stub_worker):
             queue_name = "tasks"
 
         def perform(self):
-            calls.add(self.get_task_name())
+            calls.add(self.get_task_name())  # ty: ignore[unresolved-attribute]
 
     # When I subclass BaseTask
     class FooTask(BaseTask):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -114,7 +114,7 @@ def test_join_queue_gevent_style_timeout_raises_queue_join_timeout():
 def test_join_queue_gevent_style_success():
     queue = _GeventStyleQueue(result=True)
     join_queue(queue, timeout=0.1)
-    assert queue.received_timeout == 0.1
+    assert queue.received_timeout == pytest.approx(0.1)
 
 
 def test_join_queue_stdlib_fallback_success():

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -118,7 +118,7 @@ def test_local_raise_error(local_broker):
     # Given that I have an actor that raise an exception
     @remoulade.actor()
     def raise_error():
-        raise ValueError()
+        raise ValueError
 
     local_broker.declare_actor(raise_error)
 

--- a/tests/test_pidfile.py
+++ b/tests/test_pidfile.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+import pathlib
 import signal
 import time
 
@@ -19,8 +20,7 @@ def test_cli_scrubs_stale_pid_files(start_cli):
     try:
         # Given that I have an existing file containing an old pid
         filename = "test_scrub.pid"
-        with open(filename, "w") as f:
-            f.write("999999")
+        pathlib.Path(filename).write_text("999999")
 
         # When I try to start the cli and pass that file as a PID file
         proc = start_cli("tests.test_pidfile", extra_args=["--pid-file", filename])
@@ -29,8 +29,7 @@ def test_cli_scrubs_stale_pid_files(start_cli):
         time.sleep(1)
 
         # Then the process should write its pid to the file
-        with open(filename) as f:
-            pid = int(f.read())
+        pid = int(pathlib.Path(filename).read_text())
 
         assert pid == proc.pid
 
@@ -51,8 +50,7 @@ def test_cli_aborts_when_pidfile_contains_garbage(start_cli):
     try:
         # Given that I have an existing file containing important information
         filename = "test_garbage.pid"
-        with open(filename, "w") as f:
-            f.write("important!")
+        pathlib.Path(filename).write_text("important!")
 
         # When I try to start the cli and pass that file as a PID file
         proc = start_cli("tests.test_pidfile:broker", extra_args=["--pid-file", filename])

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1,3 +1,5 @@
+# ty: ignore[invalid-assignment]
+
 import json
 import logging
 import os
@@ -324,7 +326,7 @@ def test_postgres_broker_shares_a_single_listener_across_consumers():
 def test_postgres_broker_forwards_pool_size_to_client():
     broker = PostgresBroker(url=TEST_POSTGRES_URL, middleware=[], pool_size=3)
 
-    assert broker.client.engine.pool.size() == 3
+    assert broker.client.engine.pool.size() == 3  # ty: ignore[unresolved-attribute]
 
 
 def test_postgres_broker_uses_custom_partition_settings_when_provided():
@@ -369,7 +371,7 @@ def test_postgres_broker_rejects_non_json_message_encoders():
             return {}
 
     with pytest.raises(UnsupportedMessageEncoding):
-        broker._encode_message(_MessageWithInvalidJson())
+        broker._encode_message(_MessageWithInvalidJson())  # ty: ignore[invalid-argument-type]
 
 
 def test_postgres_broker_rejects_nested_non_json_safe_payloads():
@@ -1023,7 +1025,7 @@ def test_postgres_worker_processes_a_two_actor_pipeline(postgres_broker):
     worker = Worker(postgres_broker, worker_timeout=100, worker_threads=1)
     worker.start()
     try:
-        remoulade.pipeline([first_actor.message(1), second_actor.message()]).run()
+        remoulade.pipeline([first_actor.message(1), second_actor.message()]).run()  # ty: ignore[no-matching-overload]
 
         postgres_broker.join(second_actor.queue_name, timeout=10_000)
         worker.join()

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1,3 +1,5 @@
+# ty: ignore[invalid-assignment]
+
 import json
 import logging
 import os
@@ -346,7 +348,7 @@ def test_postgres_broker_shares_a_single_listener_across_consumers():
 def test_postgres_broker_forwards_pool_size_to_client():
     broker = PostgresBroker(url=TEST_POSTGRES_URL, middleware=[], pool_size=3)
 
-    assert broker.client.engine.pool.size() == 3
+    assert broker.client.engine.pool.size() == 3  # ty: ignore[unresolved-attribute]
 
 
 def test_postgres_broker_uses_custom_partition_settings_when_provided():
@@ -391,7 +393,7 @@ def test_postgres_broker_rejects_non_json_message_encoders():
             return {}
 
     with pytest.raises(UnsupportedMessageEncoding):
-        broker._encode_message(_MessageWithInvalidJson())
+        broker._encode_message(_MessageWithInvalidJson())  # ty: ignore[invalid-argument-type]
 
 
 def test_postgres_broker_rejects_nested_non_json_safe_payloads():
@@ -1024,7 +1026,7 @@ def test_postgres_worker_processes_a_two_actor_pipeline(postgres_broker):
     worker = Worker(postgres_broker, worker_timeout=100, worker_threads=1)
     worker.start()
     try:
-        remoulade.pipeline([first_actor.message(1), second_actor.message()]).run()
+        remoulade.pipeline([first_actor.message(1), second_actor.message()]).run()  # ty: ignore[no-matching-overload]
 
         postgres_broker.join(second_actor.queue_name, timeout=10_000)
         worker.join()

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1,5 +1,3 @@
-# ty: ignore[invalid-assignment]
-
 import json
 import logging
 import os
@@ -122,6 +120,7 @@ def test_postgres_broker_creates_partitioned_queue_with_default_intervals():
     broker._queue_exists = Mock(return_value=False)
 
     conn = Mock()
+    assert broker.client.engine is not None
     broker.client.engine.begin = Mock(return_value=_StubTransaction(conn))
 
     broker.declare_queue("default")
@@ -146,6 +145,7 @@ def test_postgres_broker_uses_current_transaction_connection_for_queue_creation(
 
     transaction_connection = Mock()
 
+    assert broker.client.engine is not None
     broker.client.engine.begin = Mock(return_value=_StubTransaction(transaction_connection))
 
     with broker.tx():
@@ -174,6 +174,7 @@ def test_postgres_broker_checks_queue_existence_on_its_transaction_connection():
     broker.client.list_queues = Mock(return_value=[])
 
     transaction_connection = Mock()
+    assert broker.client.engine is not None
     broker.client.engine.begin = Mock(return_value=_StubTransaction(transaction_connection))
 
     broker.declare_queue("default")
@@ -190,6 +191,7 @@ def test_postgres_broker_counts_messages_outside_the_current_transaction():
     broker.client.metrics = Mock(return_value=Mock(queue_length=0))
 
     transaction_connection = Mock()
+    assert broker.client.engine is not None
     broker.client.engine.begin = Mock(return_value=_StubTransaction(transaction_connection))
 
     with broker.tx():
@@ -206,6 +208,7 @@ def test_postgres_broker_enables_notify_on_postgresql_queue_init():
     broker._queue_exists = Mock(return_value=False)
 
     conn = Mock()
+    assert broker.client.engine is not None
     broker.client.engine.begin = Mock(return_value=_StubTransaction(conn))
 
     broker.declare_queue("default")
@@ -364,6 +367,7 @@ def test_postgres_broker_uses_custom_partition_settings_when_provided():
     broker._queue_exists = Mock(return_value=False)
 
     conn = Mock()
+    assert broker.client.engine is not None
     broker.client.engine.begin = Mock(return_value=_StubTransaction(conn))
 
     broker.declare_queue("default")

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -74,9 +74,8 @@ def test_rabbitmq_actors_retry_with_backoff_on_failure(rabbitmq_broker, rabbitmq
         if not failure_time:
             failure_time = current_millis()
             raise RuntimeError("First failure.")
-        else:
-            success_time = current_millis()
-            succeeded.set()
+        success_time = current_millis()
+        succeeded.set()
 
     # And this actor is declared
     rabbitmq_broker.declare_actor(do_work)
@@ -88,6 +87,7 @@ def test_rabbitmq_actors_retry_with_backoff_on_failure(rabbitmq_broker, rabbitmq
     succeeded.wait(timeout=30)
 
     # I expect backoff time to have passed between sucesss and failure
+    assert success_time is not None and failure_time is not None
     assert 800 <= success_time - failure_time <= 1200
 
 
@@ -102,6 +102,7 @@ def test_rabbitmq_actors_retry_with_queue_escalation_on_failure(rabbitmq_broker,
     def do_work():
         nonlocal incoming_queues
         msg = CurrentMessage.get_current_message()
+        assert msg is not None
         incoming_queues.append(msg.queue_name)
         raise RuntimeError("Failure")
 
@@ -127,6 +128,7 @@ def test_rabbitmq_actors_retry_without_queue_escalation(rabbitmq_broker, rabbitm
     def do_work():
         nonlocal incoming_queues
         msg = CurrentMessage.get_current_message()
+        assert msg is not None
         incoming_queues.append(msg.queue_name)
         raise RuntimeError("Failure")
 
@@ -148,6 +150,7 @@ def test_rabbitmq_actors_retry_with_priority_elevation_on_failure(rabbitmq_broke
     def do_work():
         nonlocal incoming_priorities
         msg = CurrentMessage.get_current_message()
+        assert msg is not None
         incoming_priorities.append(msg._rabbitmq_message.priority)
         raise RuntimeError("Failure")
 
@@ -171,6 +174,7 @@ def test_rabbitmq_actors_retry_without_priority_elevation(rabbitmq_broker, rabbi
     def do_work():
         nonlocal incoming_priorities
         msg = CurrentMessage.get_current_message()
+        assert msg is not None
         incoming_priorities.append(msg._rabbitmq_message.priority)
         raise RuntimeError("Failure")
 
@@ -456,7 +460,7 @@ def test_rabbitmq_broker_can_use_transactions(rabbitmq_broker, rabbitmq_worker):
     # then enqueue message but raise in the transaction
     with pytest.raises(ValueError), rabbitmq_broker.tx():
         [do_work.send() for _ in range(10)]
-        raise ValueError()
+        raise ValueError
 
     # Then join on the queue
     rabbitmq_broker.join(do_work.queue_name)

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -151,7 +151,7 @@ def test_rabbitmq_actors_retry_with_priority_elevation_on_failure(rabbitmq_broke
         nonlocal incoming_priorities
         msg = CurrentMessage.get_current_message()
         assert msg is not None
-        incoming_priorities.append(msg._rabbitmq_message.priority)
+        incoming_priorities.append(msg._rabbitmq_message.priority)  # ty: ignore[unresolved-attribute]
         raise RuntimeError("Failure")
 
     # And this actor is declared
@@ -175,7 +175,7 @@ def test_rabbitmq_actors_retry_without_priority_elevation(rabbitmq_broker, rabbi
         nonlocal incoming_priorities
         msg = CurrentMessage.get_current_message()
         assert msg is not None
-        incoming_priorities.append(msg._rabbitmq_message.priority)
+        incoming_priorities.append(msg._rabbitmq_message.priority)  # ty: ignore[unresolved-attribute]
         raise RuntimeError("Failure")
 
     # And this actor is declared

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -248,7 +248,7 @@ def test_raise_on_error(stub_broker, result_backend, stub_worker, block):
     # And an actor that store a result and fail
     @remoulade.actor(store_results=True)
     def do_work():
-        raise ValueError()
+        raise ValueError
 
     # And this actor is declared
     stub_broker.declare_actor(do_work)
@@ -276,7 +276,7 @@ def test_store_errors(stub_broker, result_backend, stub_worker, block):
     # And an actor that store a result and fail
     @remoulade.actor(store_results=True)
     def do_work():
-        raise ValueError()
+        raise ValueError
 
     # And this actor is declared
     stub_broker.declare_actor(do_work)
@@ -306,7 +306,7 @@ def test_store_errors_after_no_more_retry(stub_broker, result_backend, stub_work
     @remoulade.actor(max_retries=3, store_results=True, min_backoff=10, max_backoff=100)
     def do_work():
         failures.append(1)
-        raise ValueError()
+        raise ValueError
 
     # And this actor is declared
     stub_broker.declare_actor(do_work)
@@ -398,9 +398,8 @@ def test_messages_can_get_completed(stub_broker, stub_worker, result_backend, er
     @remoulade.actor(store_results=True)
     def do_work():
         if error:
-            raise ValueError()
-        else:
-            return 42
+            raise ValueError
+        return 42
 
     # And this actor is declared
     stub_broker.declare_actor(do_work)
@@ -455,12 +454,12 @@ def test_error_cannot_be_serialized(stub_broker, stub_worker, result_middleware)
     # given a exception which is not serializable
     class UnserializableError(Exception):
         def __repr__(self):
-            raise ValueError()
+            raise ValueError
 
     # And an actor that stores results
     @remoulade.actor(store_results=True)
     def do_work():
-        raise UnserializableError()
+        raise UnserializableError
 
     # And this actor is declared
     stub_broker.declare_actor(do_work)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -413,12 +413,12 @@ def test_messages_can_get_completed(stub_broker, stub_worker, result_backend, er
 
     result = message.result
     # we can get the completion
-    assert result.completed
+    assert result.completed()
 
     result.get(forget=True, raise_on_error=False)
 
     # even after a forget
-    assert result.completed
+    assert result.completed()
 
 
 def test_result_get_forget_not_store_if_no_result(stub_broker, stub_worker, result_backend):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -204,7 +204,7 @@ def test_scheduler_wrong_weekday(stub_broker, stub_worker, scheduler, scheduler_
     scheduler.schedule = [
         ScheduledJob(
             actor_name="write_loaded_at",
-            iso_weekday=datetime.datetime.now().isoweekday() + 1,
+            iso_weekday=(datetime.datetime.now(datetime.UTC).isoweekday() % 7) + 1,
         )
     ]
     scheduler.get_redis_schedule, event = mock_func(scheduler.get_redis_schedule)
@@ -231,7 +231,7 @@ def test_scheduler_right_weekday(stub_broker, stub_worker, scheduler, scheduler_
     scheduler.schedule = [
         ScheduledJob(
             actor_name="write_loaded_at",
-            iso_weekday=datetime.datetime.now().isoweekday(),
+            iso_weekday=datetime.datetime.now(datetime.UTC).isoweekday(),
         )
     ]
     write_loaded_at.send, event = mock_func(write_loaded_at.send)


### PR DESCRIPTION
### 🧹 Spring cleaning!

**Summary of changes:**
- Added several new Ruff lints
- Migrated type checker from `mypy` to `ty`
- Removed obsolete type annotations
- Updated dev tooling & dependencies
- Updated GitHub Actions workflows
- Prepared setup for upcoming Python 3.15 support

**Verification:**
The code has been validated with:

```bash
ruff check
ruff check --preview
ruff format
ty check
pytest --benchmark-skip

# Only for the commit prior to the ty migration:
mypy --show-traceback
```

All changes are trivial and were performed either manually or via Ruff/ty autofixes.

Note: I was assisted by Gemini 3.6 Flash, conducting several review cycles before opening this PR.

I expect a slight performance boost from these cleanups (even if it's still Python 😉).