### PR TITLE
feat(tracing): add propagate_context option to OpenTelemetryMiddleware

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,15 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+`7.2.0`_ -- Unreleased
+----------------------
+Feat
+^^^^
+* ``OpenTelemetryMiddleware`` accepts ``propagate_context`` (default false). When true, the consumer span is a
+  child of the producer span and shares its ``trace_id`` instead of being a new root with a ``Link``. Meant for
+  workloads with a bounded fan-out, where one trace per business operation matters more than the protection
+  against giant traces. The ``ParentBased`` sampler then keeps or drops the whole chain at once.
+
 `7.1.1`_ -- 2026-09-02
 ----------------------
 Fix

--- a/remoulade/middleware/tracing.py
+++ b/remoulade/middleware/tracing.py
@@ -17,9 +17,10 @@
 
 """OpenTelemetry tracing middleware for Remoulade.
 
-This middleware creates **new trace roots** on the consumer side with a
-``Link`` back to the producer span, instead of propagating trace context
-as parent-child (same ``trace_id``).
+By default this middleware creates **new trace roots** on the consumer side
+with a ``Link`` back to the producer span, instead of propagating trace
+context as parent-child (same ``trace_id``). ``propagate_context=True``
+switches to parent-child propagation.
 
 Why?
 ----
@@ -34,15 +35,21 @@ This middleware breaks the parent-child chain:
 
 * **Producer side** (``before_enqueue``): starts a ``PRODUCER`` span and
   ``inject()``s the current context into ``message.options["trace_ctx"]``.
-* **Consumer side** (``before_process_message``): always starts a **new root**
-  ``CONSUMER`` span with its own ``trace_id``, independently subject to the
-  configured sampler.  When the message carries a ``trace_ctx`` dict
+* **Consumer side** (``before_process_message``): by default starts a **new
+  root** ``CONSUMER`` span with its own ``trace_id``, independently subject
+  to the configured sampler.  When the message carries a ``trace_ctx`` dict
   (injected by the producer), the consumer ``extract()``s it and attaches a
   ``Link`` back to the producer span.  Messages without ``trace_ctx`` still
   get a span but with no link.
 
 The causal relationship remains navigable in Tempo / Grafana via span
 links.
+
+``propagate_context=True`` restores parent-child propagation: the consumer
+span becomes a child of the producer span and shares its ``trace_id``, and
+no ``Link`` is added. Use it for workloads with a bounded fan-out, where one
+trace per business operation is worth more than the protection above. The
+``ParentBased`` sampler then keeps or drops the whole chain at once.
 
 Usage
 -----
@@ -77,7 +84,8 @@ class OpenTelemetryMiddleware(Middleware):
     with OpenTelemetry spans using **link-based** propagation.
 
     Each consumed message starts a new, independent trace with a
-    ``Link`` back to the producer span rather than being a child of it.
+    ``Link`` back to the producer span rather than being a child of it,
+    unless ``propagate_context`` is true.
     """
 
     def __init__(
@@ -86,6 +94,7 @@ class OpenTelemetryMiddleware(Middleware):
         *,
         tracer_name: str = "remoulade",
         schema_url: str = "https://opentelemetry.io/schemas/1.11.0",
+        propagate_context: bool = False,
     ):
         """
         Parameters
@@ -97,11 +106,16 @@ class OpenTelemetryMiddleware(Middleware):
             Name passed to ``trace.get_tracer()`` when *tracer* is *None*.
         schema_url:
             Schema URL passed to ``trace.get_tracer()`` when *tracer* is *None*.
+        propagate_context:
+            When true, the consumer span is a child of the producer span
+            and shares its ``trace_id``. When false (default), the consumer
+            span is a new root with a ``Link`` back to the producer span.
         """
         self._tracer = tracer or trace_api.get_tracer(
             tracer_name,
             schema_url=schema_url,
         )
+        self._propagate_context = propagate_context
         self._local = threading.local()
 
     @property
@@ -156,26 +170,33 @@ class OpenTelemetryMiddleware(Middleware):
     # ------------------------------------------------------------------
 
     def before_process_message(self, broker, message):
-        # Build an optional link back to the producer span.
-        links: list[trace_api.Link] = []
+        # Resolve the producer span context carried by the message, if any.
+        parent_span_ctx: trace_api.SpanContext | None = None
         trace_ctx = message.options.get("trace_ctx")
         if isinstance(trace_ctx, dict):
             parent_ctx = extract(trace_ctx)
             parent_span = trace_api.get_current_span(parent_ctx)
-            parent_span_ctx = parent_span.get_span_context() if parent_span else None
-            if parent_span_ctx and parent_span_ctx.is_valid:
+            candidate = parent_span.get_span_context() if parent_span else None
+            if candidate and candidate.is_valid:
+                parent_span_ctx = candidate
+
+        # Start the span in an explicit context so that any active span
+        # on this thread is NOT used as parent. The parent is either the
+        # producer span (propagate_context) or nothing (new root).
+        context = context_api.Context()
+        links: list[trace_api.Link] = []
+        if parent_span_ctx is not None:
+            if self._propagate_context:
+                context = trace_api.set_span_in_context(trace_api.NonRecordingSpan(parent_span_ctx), context)
+            else:
                 links.append(trace_api.Link(parent_span_ctx))
 
-        # Start a NEW root span in an **empty** context so that any
-        # active span on this thread is NOT used as parent.  This
-        # guarantees the consumer span is always a root span with its
-        # own trace_id.
         self._start_span(
             message,
             action="process",
             kind=trace_api.SpanKind.CONSUMER,
             is_publish=False,
-            context=context_api.Context(),
+            context=context,
             links=links,
         )
 

--- a/tests/middleware/test_tracing.py
+++ b/tests/middleware/test_tracing.py
@@ -24,6 +24,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.sdk.trace.sampling import ALWAYS_ON, ParentBased
 
 from remoulade import Message
 from remoulade.middleware.tracing import OpenTelemetryMiddleware
@@ -43,6 +44,18 @@ def otel_setup():
     provider.add_span_processor(SimpleSpanProcessor(exporter))
     tracer = provider.get_tracer("test-remoulade")
     middleware = OpenTelemetryMiddleware(tracer=tracer)
+    yield middleware, exporter
+    provider.shutdown()
+
+
+@pytest.fixture()
+def otel_setup_propagate():
+    """Same as ``otel_setup`` with ``propagate_context=True``."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("test-remoulade")
+    middleware = OpenTelemetryMiddleware(tracer=tracer, propagate_context=True)
     yield middleware, exporter
     provider.shutdown()
 
@@ -216,3 +229,84 @@ class TestContextIsolation:
         # Consumer span must NOT be a child of the ambient span
         assert consumer_span.context.trace_id != ambient_trace_id
         assert consumer_span.context.trace_id != producer_span.context.trace_id
+
+
+# ---------------------------------------------------------------------------
+# propagate_context=True tests
+# ---------------------------------------------------------------------------
+
+
+class TestPropagateContext:
+    def test_consumer_is_child_of_producer(self, otel_setup_propagate):
+        middleware, exporter = otel_setup_propagate
+        trace_ctx, producer_span = TestConsumer()._enqueue_and_get_trace_ctx(middleware, exporter)
+
+        consumer_message = _make_message(trace_ctx=trace_ctx)
+        middleware.before_process_message(None, consumer_message)
+        middleware.after_process_message(None, consumer_message, result=42)
+
+        assert len(exporter.get_finished_spans()) == 2
+        consumer_span = exporter.get_finished_spans()[1]
+        assert consumer_span.kind == trace_api.SpanKind.CONSUMER
+
+        # Same trace, direct child, no link
+        assert consumer_span.context.trace_id == producer_span.context.trace_id
+        assert consumer_span.parent is not None
+        assert consumer_span.parent.span_id == producer_span.context.span_id
+        assert len(consumer_span.links) == 0
+
+    def test_consumer_without_trace_ctx_is_root(self, otel_setup_propagate):
+        middleware, exporter = otel_setup_propagate
+        message = _make_message()  # no trace_ctx
+
+        middleware.before_process_message(None, message)
+        middleware.after_process_message(None, message, result=1)
+
+        assert len(exporter.get_finished_spans()) == 1
+        consumer_span = exporter.get_finished_spans()[0]
+        assert consumer_span.parent is None
+        assert len(consumer_span.links) == 0
+
+    def test_ambient_span_is_not_used_as_parent(self, otel_setup_propagate):
+        """The producer span wins over any active span on the thread."""
+        middleware, exporter = otel_setup_propagate
+        trace_ctx, producer_span = TestConsumer()._enqueue_and_get_trace_ctx(middleware, exporter)
+
+        ambient_tracer = TracerProvider().get_tracer("ambient")
+        with ambient_tracer.start_as_current_span("ambient_operation") as ambient_span:
+            consumer_message = _make_message(trace_ctx=trace_ctx)
+            middleware.before_process_message(None, consumer_message)
+            middleware.after_process_message(None, consumer_message, result=1)
+
+        consumer_span = exporter.get_finished_spans()[1]
+        assert consumer_span.context.trace_id == producer_span.context.trace_id
+        assert consumer_span.context.trace_id != ambient_span.get_span_context().trace_id
+
+    def test_invalid_trace_ctx_falls_back_to_root(self, otel_setup_propagate):
+        middleware, exporter = otel_setup_propagate
+        message = _make_message(trace_ctx={"traceparent": "garbage"})
+
+        middleware.before_process_message(None, message)
+        middleware.after_process_message(None, message, result=1)
+
+        consumer_span = exporter.get_finished_spans()[0]
+        assert consumer_span.parent is None
+        assert len(consumer_span.links) == 0
+
+    def test_parent_sampling_decision_is_inherited(self):
+        """With a ParentBased sampler, an unsampled producer yields an
+        unsampled (not exported) consumer span."""
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider(sampler=ParentBased(ALWAYS_ON))
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        tracer = provider.get_tracer("test-remoulade")
+        middleware = OpenTelemetryMiddleware(tracer=tracer, propagate_context=True)
+
+        # traceparent with trace-flags 00 => parent not sampled
+        trace_ctx = {"traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00"}
+        message = _make_message(trace_ctx=trace_ctx)
+        middleware.before_process_message(None, message)
+        middleware.after_process_message(None, message, result=1)
+
+        assert exporter.get_finished_spans() == ()
+        provider.shutdown()


### PR DESCRIPTION
## What

`OpenTelemetryMiddleware(propagate_context: bool = False)`.

- `False` (default): current behaviour. Each consumed message starts a new root span with a `Link` to the producer span.
- `True`: the consumer span is a child of the producer span and shares its `trace_id`. No `Link`.

In both modes an active span on the worker thread is never used as parent.

## Why

The link mode protects Tempo from giant traces on fan-out workloads. It also splits one business operation into many traces. With a `ParentBased` sampler each consumer trace is sampled on its own, so at 1 % most links point to traces that were dropped.

Workloads with a bounded fan-out, such as `cayzn-tracking`, want one trace per operation. `propagate_context=True` gives them that, and the `ParentBased` sampler then keeps or drops the whole chain at once.

## Tests

`tests/middleware/test_tracing.py`: 3 new tests for the propagate mode (child of producer, root without `trace_ctx`, ambient span ignored). 11 passed locally.

## Follow-up

wiremind-python exposes the option on `_RemouladeMiddlewareConfig`, cayzn-tracking-zen enables it.

---
Tracking: Notion task TASKS2-4216 https://app.notion.com/p/3d1dcbda9c3581d792cbd6ba94a32591